### PR TITLE
DOCS-791: mobile intergration pages are now full width

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -14,20 +14,20 @@
 <div class="js-toc-content">
 <div class="container">
     <div class="row">
-        <div class="col-9">
+        <div class="col-md-9">
             <div class="row">
-                <div class="col-8">
+                <div class="col-md-8">
                     <h1 id="{{ .Title}}">{{ .Title}}</h1>
                     <hr class="separator">
                 </div>
-                <div class="col-2">
+                <div class="col-md-2 d-none d-md-inline">
                     {{ if .Params.logo }}
                     <img class="plugin-logo" src="{{ .Params.logo }}">
                     {{ end }}
                 </div>
             </div>
             <div class="row pb-3">
-                <div class="col-8">
+                <div class="col-md-8">
                     {{ if .Params.description }}
                     {{ .Params.description | markdownify }}
                     {{ end }}
@@ -44,7 +44,7 @@
                     </div>
                     {{ end }}
                 </div>
-                <div class="col-2">
+                <div class="col-md-2">
                     {{ if .Params.magento_image }}
                     <img class="magento-certimage" src="{{ .Params.magento_image }}"
                         alt="{{ .Params.magento_image_alt }}">


### PR DESCRIPTION
### Basic
- We only accept documentation that is proved to work on our LIVE API
- At least 1 approval is needed before pull requests can be merged
- The article must match our Synonym word list. For external commits, a MultiSafepay employee will check
- US English must be applied
- Use bullets for numerations where the sort order doesn't matter. For chronological order, use numbers. This does not apply to changelogs
- Set link on email address.

### Text style
- Paths are written like: _Configuration → System → Plugin → MultiSafepay_
- Use single quotation marks in your Markdown code (example title: 'Title of the article')
- Use Italics for buttons, clicks, paths, etc. Do mind to close the italics before the end of a sentence followed by a period
- Numerations / bullets are punctuated with a period at the end of the numerations / bullets.
- Periods should be excluded for sentences that finish in an e-mail address (e.g. "..contact us at <example@example.com> "  )

### Images
- Screenshot recomended sizes: Width: 820px - Height: auto