### PR TITLE
DOCS-802: updated styling for allow wordbreaks in urls

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -36,7 +36,7 @@
     <link href="{{ .Site.BaseURL }}css/bootstrap.min.css" rel="stylesheet" />
     <link href="{{ .Site.BaseURL }}css/mburger.css" rel="stylesheet" />
     <link href="{{ .Site.BaseURL }}css/mmenu.css" rel="stylesheet" />
-    <link href="{{ .Site.BaseURL }}css/main.css?v=3" rel="stylesheet" />
+    <link href="{{ .Site.BaseURL }}css/main.css?v=4" rel="stylesheet" />
     <link rel="shortcut icon" type="image/png" href="/favicon.ico">
     <script src="{{ .Site.BaseURL }}js/mmenu.js"></script>
     <script src="{{ .Site.BaseURL }}js/main.js"></script>

--- a/layouts/api/list.html
+++ b/layouts/api/list.html
@@ -1,6 +1,6 @@
 {{ define "main"}}
 <!--<link href='{{ relURL "css/monokai.css" }}' rel="stylesheet" media="screen" />-->
-<link href='{{ relURL "css/api.css?v=3" }}' rel="stylesheet" media="screen" />
+<link href='{{ relURL "css/api.css?v=4" }}' rel="stylesheet" media="screen" />
 <section id="api-content">
     {{ range.Pages }}
     <article>

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -1094,3 +1094,7 @@ p {
 .faq-content dd {
 	margin-left: 15px
 }
+
+.faq-content a {
+    word-break: break-all;
+}


### PR DESCRIPTION
### Basic
- We only accept documentation that is proved to work on our LIVE API
- At least 1 approval is needed before pull requests can be merged
- The article must match our Synonym word list. For external commits, a MultiSafepay employee will check
- US English must be applied
- Use bullets for numerations where the sort order doesn't matter. For chronological order, use numbers. This does not apply to changelogs
- Set link on email address.

### Text style
- Paths are written like: _Configuration → System → Plugin → MultiSafepay_
- Use single quotation marks in your Markdown code (example title: 'Title of the article')
- Use Italics for buttons, clicks, paths, etc. Do mind to close the italics before the end of a sentence followed by a period
- Numerations / bullets are punctuated with a period at the end of the numerations / bullets.
- Periods should be excluded for sentences that finish in an e-mail address (e.g. "..contact us at <example@example.com> "  )

### Images
- Screenshot recomended sizes: Width: 820px - Height: auto