### PR TITLE
DOCS-834: Added 404 styling

### DIFF
--- a/layouts/404.html
+++ b/layouts/404.html
@@ -1,22 +1,25 @@
 {{ define "main"}}
-  <div id="main">
+<div id="main">
+  <div id="error-page-container" class="container">
     <div id="hero">
       <h1>The page you are looking for does not exist</h1>
+      <hr class="separator">
       <p class="hero-lead">
-           {{/* .Params.bref | safeHTML */}}
-      </p>
-    </div>
-    <div id="kube-component" class="center-error-page">
+       {{/* .Params.bref | safeHTML */}}
+     </p>
+   </div>
+   <div id="kube-component" class="center-error-page">
     {{ partial "toc" .}}
-    You can either <a href="/">browse our pages</a> or contact us at <a href="mailto:integration@multisafepay.com">integration@multisafepay.com</a> to request an page.
-    <div class = "padding-error-page">
-      <a id="" class="button primary big" href="/">Go to homepage</a>
+    <p>You can either <a href="/">browse our pages</a> or contact us at <a href="mailto:integration@multisafepay.com">integration@multisafepay.com</a> to request an page.</p>
+    <div class="padding-error-page">
+      <a class="button primary big" href="/">Go to homepage</a>
     </div>
-<!-- Inject script tag in this template  -->
+    <!-- Inject script tag in this template  -->
     {{if .Params.script}}
-     {{ $script := (delimit (slice "scripts" .Params.script) "/")}}
+    {{ $script := (delimit (slice "scripts" .Params.script) "/")}}
     {{ partial (string $script) .}}
     {{end }}
-    </div>
-    </div>
+  </div>
+</div>
+</div>
 {{ end }}

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -444,7 +444,7 @@ ol.breadcrumb {
 }
 
 #error-page-container .padding-error-page{
-    margin-bottom: 5rem;
+    margin-bottom: 7rem;
 }
 
 

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -439,6 +439,14 @@ ol.breadcrumb {
     border-radius: 5px;
 }
 
+#error-page-container{
+    padding-top: 6rem;
+}
+
+#error-page-container .padding-error-page{
+    margin-bottom: 5rem;
+}
+
 
 @media (min-width: 980px) {
     .primary {


### PR DESCRIPTION
### Basic
- We only accept documentation that is proved to work on our LIVE API
- At least 1 approval is needed before pull requests can be merged
- The article must match our Synonym word list. For external commits, a MultiSafepay employee will check
- US English must be applied
- Use bullets for numerations where the sort order doesn't matter. For chronological order, use numbers. This does not apply to changelogs
- Set link on email address.

### Text style
- Paths are written like: _Configuration → System → Plugin → MultiSafepay_
- Use single quotation marks in your Markdown code (example title: 'Title of the article')
- Use Italics for buttons, clicks, paths, etc. Do mind to close the italics before the end of a sentence followed by a period
- Numerations / bullets are punctuated with a period at the end of the numerations / bullets.
- Periods should be excluded for sentences that finish in an e-mail address (e.g. "..contact us at <example@example.com> "  )

### Images
- Screenshot recomended sizes: Width: 820px - Height: auto