### PR TITLE
DOCS-844: added auto layout tables

### DIFF
--- a/content/api/orders/patch_order.md
+++ b/content/api/orders/patch_order.md
@@ -43,4 +43,4 @@ Update the order details.
 | ship_date                   | string  | The date that the order was shipped.                                                       |
 | reason                      | string  | Add a short free text memo to the order when setting the shipping status.                  |
 | invoice_id                  | string  | Update an existing order with a reference to your internal invoice id. The invoice id will be added to financial reports and exports generated within MultiSafepay Control. |
-{{< description >}}
+{{< /description >}}

--- a/content/api/orders/post_order_direct.md
+++ b/content/api/orders/post_order_direct.md
@@ -115,4 +115,4 @@ IDEAL, CREDITCARDS, PAYAFTER, EINVOICE, KLARNA, KLARNA_ACC, DIRDEB, DIRECTBANK, 
 | notification_method            | string    | Sends push notification (POST,GET) default: GET. | 
 | redirect_url                   | string    | Customer will be redirected to this page after a successful payment. In the event that the transaction is marked with the status uncleared, the customer will also be redirected to this page of the webshop. The uncleared status will not be passed on to the customer who will experience the payment as successful at all times. |
 | cancel_url                     | string    | Customer will be redirected to this page after a failed payment.  |                                                  
-{{< description >}}
+{{< /description >}}

--- a/content/api/orders/post_order_recurring.md
+++ b/content/api/orders/post_order_recurring.md
@@ -106,4 +106,4 @@ For more information about recurring payments, please refer to our [dedicated pa
 | redirect_url                   | string    | Customer will be redirected to this page after a successful payment. In the event that the transaction is marked with the status uncleared, the customer will also be redirected to this page of the webshop. The uncleared status will not be passed on to the customer who will experience the payment as successful at all times. |
 | cancel_url                     | string    | Customer will be redirected to this page after a failed payment.  |  
 
-{{< description >}}
+{{< /description >}}

--- a/static/css/api.css
+++ b/static/css/api.css
@@ -281,6 +281,6 @@ span.m {
 }
 
 .content table {
-	table-layout: fixed;
+	table-layout: auto;
     width: 100%;
 }


### PR DESCRIPTION
### Basic
- We only accept documentation that is proved to work on our LIVE API
- At least 1 approval is needed before pull requests can be merged
- The article must match our Synonym word list. For external commits, a MultiSafepay employee will check
- US English must be applied
- Use bullets for numerations where the sort order doesn't matter. For chronological order, use numbers. This does not apply to changelogs
- Set link on email address.

### Text style
- Paths are written like: _Configuration → System → Plugin → MultiSafepay_
- Use single quotation marks in your Markdown code (example title: 'Title of the article')
- Use Italics for buttons, clicks, paths, etc. Do mind to close the italics before the end of a sentence followed by a period
- Numerations / bullets are punctuated with a period at the end of the numerations / bullets.
- Periods should be excluded for sentences that finish in an e-mail address (e.g. "..contact us at <example@example.com> "  )

### Images
- Screenshot recomended sizes: Width: 820px - Height: auto