### PR TITLE
DOCS-1337: remove afterpay from list of payment methods in prestashop 1.6

### DIFF
--- a/content/integrations/plugins/prestashop-1-6/faq/available-payment-methods-prestashop.md
+++ b/content/integrations/plugins/prestashop-1-6/faq/available-payment-methods-prestashop.md
@@ -30,7 +30,6 @@ __Banks__
 
 __Billing suite__
 
-+ [Afterpay](/payment-methods/billing-suite/afterpay/)
 + [E-Invoicing](/payment-methods/billing-suite/e-invoicing/)
 + [Klarna](/payment-methods/billing-suite/klarna/)
 + [Pay After Delivery](/payment-methods/billing-suite/pay-after-delivery/)


### PR DESCRIPTION
removed afterpay from the available payment methods in prestashop 1.6 as it is not available

look I made a pull request