### PR TITLE
DOCS-1098: trim feedback url suffix only

### DIFF
--- a/layouts/partials/edit-page.html
+++ b/layouts/partials/edit-page.html
@@ -16,7 +16,7 @@
                 </p>
                 <p class="my-4">
                     <a target="_self" class="rounded px-4 py-3 border border-dark text-dark"
-                        href='https://github.com/MultiSafepay/docs/blob/master/content/{{ strings.TrimRight "_index.md" .File.Path }}'>Feedback</a>
+                        href='https://github.com/MultiSafepay/docs/blob/master/content/{{ strings.TrimSuffix "_index.md" .File.Path }}'>Feedback</a>
                 </p>
             </div>
         </div>


### PR DESCRIPTION
### Basic
- We only accept documentation that is proved to work on our LIVE API
- At least 1 approval is needed before pull requests can be merged
- The article must match our Synonym word list. For external commits, a MultiSafepay employee will check
- US English must be applied
- Use bullets for numerations where the sort order doesn't matter. For chronological order, use numbers. This does not apply to changelogs
- Set link on email address.

### Text style
- Paths are written like: _Configuration → System → Plugin → MultiSafepay_
- Use single quotation marks in your Markdown code (example title: 'Title of the article')
- Use Italics for buttons, clicks, paths, etc. Do mind to close the italics before the end of a sentence followed by a period
- Numerations / bullets are punctuated with a period at the end of the numerations / bullets.
- Periods should be excluded for sentences that finish in an e-mail address (e.g. "..contact us at <example@example.com> "  )

### Images
- Screenshot recomended sizes: Width: 820px - Height: auto