### PR TITLE
DOCS-1141: Refund not possible if Fooman surcharge is used

### DIFF
--- a/content/integrations/plugins/magento2/faq/payment-fee-surcharges.md
+++ b/content/integrations/plugins/magento2/faq/payment-fee-surcharges.md
@@ -11,6 +11,8 @@ Adding a payment fee or [Surcharge](/faq/getting-started/glossary/#surcharge) is
 
 However, an external package of [Fooman](https://store.fooman.co.nz/extensions/magento2) is available. This allows you to still add a payment fee or surcharge within the desired payment method.
 
+Refunding from the Magento 2 backend is disabled when the order has a Fooman Surcharge. It is still possible to refund those orders through [MultiSafepay Control](https://merchant.multisafepay.com)
+
 >_Do mind that because an external module has to be installed, our Integration Team's help will be limited_.
 
 Of course, we do our best to support and assist as best as possible, but we investigate or reproduce on the core of a plugin. Therefore, we do not guarantee a perfect compatibility when installing an external package.

--- a/content/integrations/plugins/magento2/faq/refunding-magento2.md
+++ b/content/integrations/plugins/magento2/faq/refunding-magento2.md
@@ -8,3 +8,4 @@ read_more: "."
 Yes, it is possible to refund orders or credit memo from within the Magento 2 backend.  
 You can also refund from your [MultiSafepay Control](https://merchant.multisafepay.com)
 
+Refunding from the Magento 2 backend is disabled when the order has a Fooman Surcharge. It is still possible to refund those orders through [MultiSafepay Control](https://merchant.multisafepay.com)


### PR DESCRIPTION
### Basic
- We only accept documentation that is proved to work on our LIVE API
- At least 1 approval is needed before pull requests can be merged
- The article must match our Synonym word list. For external commits, a MultiSafepay employee will check
- US English must be applied
- Use bullets for numerations where the sort order doesn't matter. For chronological order, use numbers. This does not apply to changelogs
- Set link on email address.

### Text style
- Paths are written like: _Configuration → System → Plugin → MultiSafepay_
- Use single quotation marks in your Markdown code (example title: 'Title of the article')
- Use Italics for buttons, clicks, paths, etc. Do mind to close the italics before the end of a sentence followed by a period
- Numerations / bullets are punctuated with a period at the end of the numerations / bullets.
- Periods should be excluded for sentences that finish in an e-mail address (e.g. "..contact us at <example@example.com> "  )

### Images
- Screenshot recomended sizes: Width: 820px - Height: auto