### PR TITLE
DOCS-1548: fixed-grammar-mistake

### DIFF
--- a/content/faq/api/difference-between-status-and-transaction-status.md
+++ b/content/faq/api/difference-between-status-and-transaction-status.md
@@ -15,6 +15,6 @@ On [API](/api) level, this is illustrated as:
 
 The _status_ is related status of the webshop order. In your MultiSafepay Control, this is referred to as the _Order Status_.
 
-The _financial status_ is related to the payout of of the transaction. In your MultiSafepay Control, this is referred to as the _Status_.
+The _financial status_ is related to the payout of the transaction. In your MultiSafepay Control, this is referred to as the _Status_.
 
 


### PR DESCRIPTION
### Basic
- We only accept documentation that is proved to work on our LIVE API
- At least 1 approval is needed before pull requests can be merged
- The article must match our Synonym word list. For external commits, a MultiSafepay employee will check
- US English must be applied
- Use bullets for numerations where the sort order doesn't matter. For chronological order, use numbers. This does not apply to changelogs
- Set link on email address.

### Text style
- Paths are written like: _Configuration → System → Plugin → MultiSafepay_
- Use single quotation marks in your Markdown code (example title: 'Title of the article')
- Use Italics for buttons, clicks, paths, etc. Do mind to close the italics before the end of a sentence followed by a period
- Numerations / bullets are punctuated with a period at the end of the numerations / bullets.
- Periods should be excluded for sentences that finish in an e-mail address (e.g. "..contact us at <example@example.com> "  )

### Images
- Screenshot recomended sizes: Width: 820px - Height: auto