### PR TITLE
DOCS-1604: V Pay spelling correction across DOCS

### DIFF
--- a/content/integrations/plugins/craftcommerce/faq/available-payment-methods-craft-commerce.md
+++ b/content/integrations/plugins/craftcommerce/faq/available-payment-methods-craft-commerce.md
@@ -30,7 +30,7 @@ __Banks__
 + [SOFORT Banking](/payment-methods/banks/sofort-banking)
 + [Trustly](/payment-methods/banks/trustly)
 + [TrustPay](/payment-methods/banks/trustpay)
-+ [VPAY](/payment-methods/credit-and-debit-cards/vpay/)
++ [V PAY](/payment-methods/credit-and-debit-cards/vpay/)
 
 __Billing suite__
 

--- a/content/integrations/plugins/cs-cart/faq/available-payment-methods-cs-cart.md
+++ b/content/integrations/plugins/cs-cart/faq/available-payment-methods-cs-cart.md
@@ -28,7 +28,7 @@ __Banks__
 + [SOFORT Banking](/payment-methods/banks/sofort-banking)
 + [Trustly](/payment-methods/banks/trustly)
 + [TrustPay](/payment-methods/banks/trustpay)
-+ [VPAY](/payment-methods/credit-and-debit-cards/vpay/)
++ [V PAY](/payment-methods/credit-and-debit-cards/vpay/)
 
 __Billing suite__
 

--- a/content/integrations/plugins/drupal7/faq/available-payment-methods-drupal.md
+++ b/content/integrations/plugins/drupal7/faq/available-payment-methods-drupal.md
@@ -27,7 +27,7 @@ __Banks__
 + [Maestro](/payment-methods/maestro)
 + [SOFORT Banking](/payment-methods/banks/sofort-banking)
 + [TrustPay](/payment-methods/banks/trustpay)
-+ [VPAY](/payment-methods/credit-and-debit-cards/vpay/)
++ [V PAY](/payment-methods/credit-and-debit-cards/vpay/)
 
 __Billing suite__
 

--- a/content/integrations/plugins/drupal8/faq/available-payment-methods-drupal8.md
+++ b/content/integrations/plugins/drupal8/faq/available-payment-methods-drupal8.md
@@ -29,7 +29,7 @@ __Banks__
 + [SOFORT Banking](/payment-methods/banks/sofort-banking)
 + [Trustly](/payment-methods/banks/trustly)
 + [TrustPay](/payment-methods/banks/trustpay)
-+ [VPAY](/payment-methods/credit-and-debit-cards/vpay/)
++ [V PAY](/payment-methods/credit-and-debit-cards/vpay/)
 
 
 __Billing suite__

--- a/content/integrations/plugins/magento1/faq/available-payment-methods-magento1.md
+++ b/content/integrations/plugins/magento1/faq/available-payment-methods-magento1.md
@@ -28,7 +28,7 @@ __Banks__
 + [Maestro](/payment-methods/maestro)
 + [SOFORT Banking](/payment-methods/banks/sofort-banking)
 + [Trustly](/payment-methods/banks/trustly)
-+ [VPAY](/payment-methods/credit-and-debit-cards/vpay/)
++ [V PAY](/payment-methods/credit-and-debit-cards/vpay/)
 
 
 __Billing suite__

--- a/content/integrations/plugins/magento2/faq/available-payment-methods-magento2.md
+++ b/content/integrations/plugins/magento2/faq/available-payment-methods-magento2.md
@@ -30,7 +30,7 @@ __Banks__
 + [SOFORT Banking](/payment-methods/banks/sofort-banking)
 + [Trustly](/payment-methods/banks/trustly)
 + [TrustPay](/payment-methods/banks/trustpay)
-+ [VPAY](/payment-methods/credit-and-debit-cards/vpay/)
++ [V PAY](/payment-methods/credit-and-debit-cards/vpay/)
 
 
 __Billing suite__

--- a/content/integrations/plugins/opencart/faq/available-payment-methods-opencart.md
+++ b/content/integrations/plugins/opencart/faq/available-payment-methods-opencart.md
@@ -30,7 +30,7 @@ __Banks__
 + [SEPA Direct Debit](/payment-methods/banks/sepa-direct-debit)
 + [SOFORT Banking](/payment-methods/banks/sofort-banking)
 + [Trustly](/payment-methods/banks/trustly)
-+ [VPAY](/payment-methods/credit-and-debit-cards/vpay/)
++ [V PAY](/payment-methods/credit-and-debit-cards/vpay/)
 
 
 __Billing suite__

--- a/content/integrations/plugins/oscommerce/faq/available-payment-methods-oscommerce.md
+++ b/content/integrations/plugins/oscommerce/faq/available-payment-methods-oscommerce.md
@@ -23,7 +23,7 @@ __Banks__
 + [KBC](/payment-methods/banks/kbc)
 + [Maestro](/payment-methods/maestro)
 + [SOFORT Banking](/payment-methods/banks/sofort-banking)
-+ [VPAY](/payment-methods/credit-and-debit-cards/vpay/)
++ [V PAY](/payment-methods/credit-and-debit-cards/vpay/)
 
 
 __Billing suite__

--- a/content/integrations/plugins/prestashop-1-6/faq/available-payment-methods-prestashop.md
+++ b/content/integrations/plugins/prestashop-1-6/faq/available-payment-methods-prestashop.md
@@ -27,7 +27,7 @@ __Banks__
 + [CBC](/payment-methods/banks/cbc)
 + [Maestro](/payment-methods/maestro)
 + [SOFORT Banking](/payment-methods/banks/sofort-banking)
-+ [VPAY](/payment-methods/credit-and-debit-cards/vpay/)
++ [V PAY](/payment-methods/credit-and-debit-cards/vpay/)
 
 
 

--- a/content/integrations/plugins/prestashop-1-7/faq/available-payment-methods-prestashop.md
+++ b/content/integrations/plugins/prestashop-1-7/faq/available-payment-methods-prestashop.md
@@ -28,7 +28,7 @@ __Banks__
 + [SOFORT Banking](/payment-methods/banks/sofort-banking)
 + [Trustly](/payment-methods/banks/trustly)
 + [TrustPay](/payment-methods/banks/trustpay)
-+ [VPAY](/payment-methods/credit-and-debit-cards/vpay/)
++ [V PAY](/payment-methods/credit-and-debit-cards/vpay/)
 
 
 __Billing suite__

--- a/content/integrations/plugins/shopware5/faq/available-payment-methods-shopware5.md
+++ b/content/integrations/plugins/shopware5/faq/available-payment-methods-shopware5.md
@@ -30,7 +30,7 @@ __Banks__
 + [SOFORT Banking](/payment-methods/banks/sofort-banking)
 + [Trustly](/payment-methods/banks/trustly)
 + [TrustPay](/payment-methods/banks/trustpay)
-+ [VPAY](/payment-methods/credit-and-debit-cards/vpay/)
++ [V PAY](/payment-methods/credit-and-debit-cards/vpay/)
 
 
 __Billing suite__

--- a/content/integrations/plugins/shopware6/faq/available-payment-methods-shopware6.md
+++ b/content/integrations/plugins/shopware6/faq/available-payment-methods-shopware6.md
@@ -29,7 +29,7 @@ __Banks__
 + [SOFORT Banking](/payment-methods/banks/sofort-banking)
 + [Trustly](/payment-methods/banks/trustly)
 + [TrustPay](/payment-methods/banks/trustpay)
-+ [VPAY](/payment-methods/credit-and-debit-cards/vpay/)
++ [V PAY](/payment-methods/credit-and-debit-cards/vpay/)
 
 
 __Billing suite__

--- a/content/integrations/plugins/virtuemart/faq/available-payment-methods-virtuemart.md
+++ b/content/integrations/plugins/virtuemart/faq/available-payment-methods-virtuemart.md
@@ -21,7 +21,7 @@ __Banks__
 + [SOFORT Banking](/payment-methods/sofort-banking)
 + [Trustly](/payment-methods/trustly)
 + [TrustPay](/payment-methods/trustpay)
-+ [VPAY](/payment-methods/credit-and-debit-cards/vpay/)
++ [V PAY](/payment-methods/credit-and-debit-cards/vpay/)
 
 
 __Prepaid cards__ 

--- a/content/integrations/plugins/woocommerce/faq/available-payment-methods-woocommerce.md
+++ b/content/integrations/plugins/woocommerce/faq/available-payment-methods-woocommerce.md
@@ -28,7 +28,7 @@ __Banks__
 + [Maestro](/payment-methods/maestro)
 + [SOFORT Banking](/payment-methods/banks/sofort-banking)
 + [Trustly](/payment-methods/banks/trustly)
-+ [VPAY](/payment-methods/credit-and-debit-cards/vpay/)
++ [V PAY](/payment-methods/credit-and-debit-cards/vpay/)
 
 
 __Billing suite__

--- a/content/integrations/plugins/x-cart/faq/available-payment-methods-x-cart.md
+++ b/content/integrations/plugins/x-cart/faq/available-payment-methods-x-cart.md
@@ -28,7 +28,7 @@ __Banks__
 + [SOFORT Banking](/payment-methods/banks/sofort-banking)
 + [Trustly](/payment-methods/banks/trustly)
 + [TrustPay](/payment-methods/banks/trustpay)
-+ [VPAY](/payment-methods/credit-and-debit-cards/vpay/)
++ [V PAY](/payment-methods/credit-and-debit-cards/vpay/)
 
 
 __Billing suite__

--- a/content/integrations/plugins/zencart/faq/available-payment-methods-zen-cart.md
+++ b/content/integrations/plugins/zencart/faq/available-payment-methods-zen-cart.md
@@ -27,7 +27,7 @@ __Banks__
 + [Maestro](/payment-methods/maestro)
 + [SOFORT Banking](/payment-methods/banks/sofort-banking)
 + [Trustly](/payment-methods/banks/trustly)
-+ [VPAY](/payment-methods/credit-and-debit-cards/vpay/)
++ [V PAY](/payment-methods/credit-and-debit-cards/vpay/)
 
 
 __Billing suite__


### PR DESCRIPTION
### Basic
- We only accept documentation that is proved to work on our LIVE API
- At least 1 approval is needed before pull requests can be merged
- The article must match our Synonym word list. For external commits, a MultiSafepay employee will check
- US English must be applied
- Use bullets for numerations where the sort order doesn't matter. For chronological order, use numbers. This does not apply to changelogs
- Set link on email address.

### Text style
- Paths are written like: _Configuration → System → Plugin → MultiSafepay_
- Use single quotation marks in your Markdown code (example title: 'Title of the article')
- Use Italics for buttons, clicks, paths, etc. Do mind to close the italics before the end of a sentence followed by a period
- Numerations / bullets are punctuated with a period at the end of the numerations / bullets.
- Periods should be excluded for sentences that finish in an e-mail address (e.g. "..contact us at <example@example.com> "  )

### Images
- Screenshot recomended sizes: Width: 820px - Height: auto