### PR TITLE
DOCS-1388: added-link-github-footer

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -17,7 +17,7 @@
           <li><a href="https://www.multisafepay.com/support/">Support</a></li>
           <li><a href="https://testmerchant.multisafepay.com/signup">Open a test account</a></li>
           <li><a href="https://status.multisafepay.com/">Status page</a></li>
-          <li><a href="https://github.com/MultiSafepay/docs/tree/master/content">Github</a></li>
+          <li><a href="https://github.com/MultiSafepay/docs/tree/master/content">GitHub</a></li>
         </ul>
       </div>
       <div class="col-12 col-md-3">

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -17,6 +17,7 @@
           <li><a href="https://www.multisafepay.com/support/">Support</a></li>
           <li><a href="https://testmerchant.multisafepay.com/signup">Open a test account</a></li>
           <li><a href="https://status.multisafepay.com/">Status page</a></li>
+          <li><a href="https://github.com/MultiSafepay/docs/tree/master/content">Github</a></li>
         </ul>
       </div>
       <div class="col-12 col-md-3">


### PR DESCRIPTION
### Basic
- We only accept documentation that is proved to work on our LIVE API
- At least 1 approval is needed before pull requests can be merged
- The article must match our Synonym word list. For external commits, a MultiSafepay employee will check
- US English must be applied
- Use bullets for numerations where the sort order doesn't matter. For chronological order, use numbers. This does not apply to changelogs
- Set link on email address.

### Text style
- Paths are written like: _Configuration → System → Plugin → MultiSafepay_
- Use single quotation marks in your Markdown code (example title: 'Title of the article')
- Use Italics for buttons, clicks, paths, etc. Do mind to close the italics before the end of a sentence followed by a period
- Numerations / bullets are punctuated with a period at the end of the numerations / bullets.
- Periods should be excluded for sentences that finish in an e-mail address (e.g. "..contact us at <example@example.com> "  )

### Images
- Screenshot recomended sizes: Width: 820px - Height: auto