### PR TITLE
DOCS-1615: added-feedback-lang-block-everywhere

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -101,6 +101,15 @@
         {{ block "main" . }}{{ end }}
         {{ if not .IsHome }}
 
+
+        <div class="container">
+    <div class="row">
+        {{ partial "edit-page" . }}
+        {{ partial "bottom-block" . }}
+    </div>
+</div>
+
+
         <footer class="footer-background">
             {{ else }}
             <footer>

--- a/layouts/_default/faqdetail.html
+++ b/layouts/_default/faqdetail.html
@@ -37,13 +37,6 @@
     </section>
 </div>
 
-<div class="container">
-    <div class="row">
-        {{ partial "edit-page" . }}
-        {{ partial "bottom-block" . }}
-    </div>
-</div>
-
 <script src="{{ "/js/scroll-offset.js" | relURL }}"></script>
 <script src="{{ .Site.BaseURL }}js/tocbot.min.js"></script>
 <script src="{{ .Site.BaseURL }}js/scroll-menu.js"></script>

--- a/layouts/_default/faqplugins.html
+++ b/layouts/_default/faqplugins.html
@@ -41,7 +41,6 @@
       {{ end }}
     </div>
   </section>
-  {{ partial "bottom-block" . }}
 </div>
 
 

--- a/layouts/_default/paymentdetail.html
+++ b/layouts/_default/paymentdetail.html
@@ -31,8 +31,6 @@
       </div>
     </div>
 </section>
-{{ partial "edit-page" .}}
-{{ partial "bottom-block" . }}
 </div>
 <script src="{{ "/js/scroll-offset.js" | relURL }}"></script>
 <script src="{{ .Site.BaseURL }}js/tocbot.min.js"></script>

--- a/layouts/_default/single-beta-button.html
+++ b/layouts/_default/single-beta-button.html
@@ -64,10 +64,6 @@
             </div>
         </div>
     </div>
-    {{ if or (eq .Section "faq") (eq .Section "tools") }}
-    {{ partial "edit-page" . }}
-    {{ partial "bottom-block" . }}
-    {{ end }}
 </div>
 {{ if isset .Params "manual" }}
       {{ partial "manual" . }}

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -61,10 +61,6 @@
             </div>
         </div>
     </div>
-    {{ if or (eq .Section "faq") (eq .Section "tools") }}
-    {{ partial "edit-page" . }}
-    {{ partial "bottom-block" . }}
-    {{ end }}
 </div>
 {{ if isset .Params "manual" }}
       {{ partial "manual" . }}


### PR DESCRIPTION
### Basic
- We only accept documentation that is proved to work on our LIVE API
- At least 1 approval is needed before pull requests can be merged
- The article must match our Synonym word list. For external commits, a MultiSafepay employee will check
- US English must be applied
- Use bullets for numerations where the sort order doesn't matter. For chronological order, use numbers. This does not apply to changelogs
- Set link on email address.

### Text style
- Paths are written like: _Configuration → System → Plugin → MultiSafepay_
- Use single quotation marks in your Markdown code (example title: 'Title of the article')
- Use Italics for buttons, clicks, paths, etc. Do mind to close the italics before the end of a sentence followed by a period
- Numerations / bullets are punctuated with a period at the end of the numerations / bullets.
- Periods should be excluded for sentences that finish in an e-mail address (e.g. "..contact us at <example@example.com> "  )

### Images
- Screenshot recomended sizes: Width: 820px - Height: auto