### PR TITLE
Changed hyperlink on 'Contact' button in sidebar

### DIFF
--- a/layouts/partials/menu.html
+++ b/layouts/partials/menu.html
@@ -82,7 +82,7 @@
                 },
                 {
                     position: 'bottom',
-                    content: ['<div class="menu-buttons"><a href="https://www.multisafepay.com/contact" class="outline bg-white text-dark" >Contact</a><a href="https://merchant.multisafepay.com/signup" class="primary text-white"><img class=signup src="/svgs/Login.svg"></img>Sign up</a></div>']
+                    content: ['<div class="menu-buttons"><a href="https://www.multisafepay.com/contact/merchant-support" class="outline bg-white text-dark" >Contact</a><a href="https://merchant.multisafepay.com/signup" class="primary text-white"><img class=signup src="/svgs/Login.svg"></img>Sign up</a></div>']
                 },
             ],
             searchfield: {


### PR DESCRIPTION
Contact page of main domain was changed. The contact-form is now nested.
In order to prevent users from looping between docs and contact,
the hyperlink on the 'Contact' button is changed from
https://www.multisafepay.com/contact to
https://www.multisafepay.com/contact/merchant-support

Signed-off-by: Kris Stallenberg <kris@MacBook-Pro-2.local>

### Basic
- We only accept documentation that is proved to work on our LIVE API
- At least 1 approval is needed before pull requests can be merged
- The article must match our Synonym word list. For external commits, a MultiSafepay employee will check
- US English must be applied
- Use bullets for numerations where the sort order doesn't matter. For chronological order, use numbers. This does not apply to changelogs
- Set link on email address.

### Text style
- Paths are written like: _Configuration → System → Plugin → MultiSafepay_
- Use single quotation marks in your Markdown code (example title: 'Title of the article')
- Use Italics for buttons, clicks, paths, etc. Do mind to close the italics before the end of a sentence followed by a period
- Numerations / bullets are punctuated with a period at the end of the numerations / bullets.
- Periods should be excluded for sentences that finish in an e-mail address (e.g. "..contact us at <example@example.com> "  )

### Images
- Screenshot recomended sizes: Width: 820px - Height: auto