### PR TITLE
DOCS-1665: Fixed typo in meta_title

### DIFF
--- a/content/integrations/wrappers/_index.md
+++ b/content/integrations/wrappers/_index.md
@@ -2,7 +2,7 @@
 title: 'Wrappers & SDK'
 breadcrumb_title: "Wrappers & SDK"
 layout: 'listplugins'
-meta_title: 'Wrapper & SDA integration - MultiSafepay Documentation Center'
+meta_title: 'Wrapper & SDK integration - MultiSafepay Documentation Center'
 meta_description: "The MultiSafepay Documentation Center presents all relevant information about our Plugins and API. You can also find support pages for Payment Methods, Tools and General Questions as well as the contact details of our Support and Integration Teams."
 logo: '/svgs/Wrappers.svg'
 short_description: 'In house developed wrappers for some of the most popular programming languages.'


### PR DESCRIPTION
The field meta_title in file _index.md said 'Wrapper & SDA integration[...]'
Changed the field to 'Wrapper & SDK integration[...]'

Signed-off-by: Kris-MultiSafepay <kris@MacBook-Pro-2.local>

### Basic
- We only accept documentation that is proved to work on our LIVE API
- At least 1 approval is needed before pull requests can be merged
- The article must match our Synonym word list. For external commits, a MultiSafepay employee will check
- US English must be applied
- Use bullets for numerations where the sort order doesn't matter. For chronological order, use numbers. This does not apply to changelogs
- Set link on email address.

### Text style
- Paths are written like: _Configuration → System → Plugin → MultiSafepay_
- Use single quotation marks in your Markdown code (example title: 'Title of the article')
- Use Italics for buttons, clicks, paths, etc. Do mind to close the italics before the end of a sentence followed by a period
- Numerations / bullets are punctuated with a period at the end of the numerations / bullets.
- Periods should be excluded for sentences that finish in an e-mail address (e.g. "..contact us at <example@example.com> "  )

### Images
- Screenshot recomended sizes: Width: 820px - Height: auto