### PR TITLE
DOCS-1709: Fix Odoo Plugin page

### DIFF
--- a/content/integrations/plugins/odoo/_index.md
+++ b/content/integrations/plugins/odoo/_index.md
@@ -1,12 +1,12 @@
 ---
 title: "MultiSafepay plugin for Odoo"
-breadcrumb_title: "Odoo"
 github_url : "https://github.com/MultiSafepay/official-odoo-integration"
 download_url : "https://github.com/MultiSafepay/official-odoo-integration/archive/13.0-develop.zip"
+breadcrumb_title: "Odoo"
 changelog_url : "."
 manual: "."
 faq: "."
-layout: 'single-beta-button'
+layout: 'single'
 meta_title: "Odoo plugin integration - MultiSafepay Docs"		
 meta_description: "MultiSafepay plugin for Odoo. Easily integrate MultiSafepay payment solutions into your Odoo platform with the free plugin"
 description : "Easily integrate MultiSafepay payment solutions into your Odoo webshop with the free and completely new MultiSafepay Odoo plugin. Our Odoo plugin is professionally supported by a certified Odoo Solution Specialist and receives regular updates to support the latest features provided by Odoo and MultiSafepay."

--- a/content/integrations/plugins/odoo/manual.md
+++ b/content/integrations/plugins/odoo/manual.md
@@ -56,7 +56,3 @@ You have installed and configured the plugin successfully. If you have any quest
 1.  Navigate to _Apps_ menu
 2.  Search and open _MultiSafepay payments_ module
 3.  Click _Upgrade_.
-
-
-
-


### PR DESCRIPTION
For some reason the _index file in content/integrations/plugins/odoo
had a different lay-out causing it to be displayed incorrectly.
Additionally removed some trailing empty lines.

Signed-off-by: Kris-MultiSafepay <kris.stallenberg@multisafepay.com>

### Basic
- We only accept documentation that is proved to work on our LIVE API
- At least 1 approval is needed before pull requests can be merged
- The article must match our Synonym word list. For external commits, a MultiSafepay employee will check
- US English must be applied
- Use bullets for numerations where the sort order doesn't matter. For chronological order, use numbers. This does not apply to changelogs
- Set link on email address.

### Text style
- Paths are written like: _Configuration → System → Plugin → MultiSafepay_
- Use single quotation marks in your Markdown code (example title: 'Title of the article')
- Use Italics for buttons, clicks, paths, etc. Do mind to close the italics before the end of a sentence followed by a period
- Numerations / bullets are punctuated with a period at the end of the numerations / bullets.
- Periods should be excluded for sentences that finish in an e-mail address (e.g. "..contact us at <example@example.com> "  )

### Images
- Screenshot recomended sizes: Width: 820px - Height: auto