### PR TITLE
DOCS-1714: Uniform meta_titles

### DIFF
--- a/content/api/payment_methods/post_order_in3.md
+++ b/content/api/payment_methods/post_order_in3.md
@@ -1,6 +1,6 @@
 ---
 weight: 301
-meta_title: "API - Create an in3 order - Developers MultiSafepay"
+meta_title: "API - Create an in3 order - MultiSafepay Docs"
 meta_description: "The MultiSafepay Documentation Center presents all relevant information about our Plugins and API. You can also find support pages for Payment Methods, Tools and General Questions as well as the contact details of our Support and Integration Teams."
 ---
 {{< code-block >}}

--- a/content/faq/general/where-find-logo-payment-methods.md
+++ b/content/faq/general/where-find-logo-payment-methods.md
@@ -1,6 +1,6 @@
 ---
 title : "Where can I find the payment method logos?"
-meta_title: "FAQ General - Where can I find the payment method logos?"
+meta_title: "FAQ General - Where can I find the payment method logos? - MultiSafepay Docs"
 meta_description: "The MultiSafepay Documentation Center presents all relevant information about our Plugins and API. You can also find support pages for Payment Methods, Tools and General Questions as well as the contact details of our Support and Integration Teams."
 read_more: "."
 ---

--- a/content/how-to-find-us/_index.md
+++ b/content/how-to-find-us/_index.md
@@ -2,6 +2,6 @@
 title: 'How to find us'
 tags: 'hidden'
 weight: 64
-meta_title: "Route to our Amsterdam Office"
+meta_title: "Route to our Amsterdam Office - MultiSafepay Docs"
 meta_description: "The MultiSafepay Documentation Center presents all relevant information about our Plugins and API. You can also find support pages for Payment Methods, Tools and General Questions as well as the contact details of our Support and Integration Teams."
 ---

--- a/content/how-to-find-us/amsterdam-office-location.md
+++ b/content/how-to-find-us/amsterdam-office-location.md
@@ -1,7 +1,7 @@
 ---
 title: "Route to our Amsterdam office"
 weight: 65
-meta_title: "Route to our Amsterdam office"
+meta_title: "Route to our Amsterdam office - MultiSafepay Docs"
 meta_description: "The MultiSafepay Documentation Center presents all relevant information about our Plugins and API. You can also find support pages for Payment Methods, Tools and General Questions as well as the contact details of our Support and Integration Teams."
 ---
 

--- a/content/how-to-find-us/malaga-office-location.md
+++ b/content/how-to-find-us/malaga-office-location.md
@@ -1,7 +1,7 @@
 ---
 title: "Route to our Malaga office"
 weight: 65
-meta_title: "Route to our Malaga office"
+meta_title: "Route to our Malaga office - MultiSafepay Docs"
 meta_description: "The MultiSafepay Documentation Center presents all relevant information about our Plugins and API. You can also find support pages for Payment Methods, Tools and General Questions as well as the contact details of our Support and Integration Teams."
 ---
 

--- a/content/integrations/accounting and bookkeeping/Snelstart reconciliation plugins by Premarc/_index.md
+++ b/content/integrations/accounting and bookkeeping/Snelstart reconciliation plugins by Premarc/_index.md
@@ -1,7 +1,7 @@
 ---
 title: "Snelstart reconciliation by Premarc"
 weight: 20
-meta_title: "Snelstart reconciliation by Premarc - MultiSafepay Support"
+meta_title: "Snelstart reconciliation by Premarc - MultiSafepay Docs"
 meta_description: "The MultiSafepay Documentation Center presents all relevant information about our Plugins and API. You can also find support pages for Payment Methods, Tools and General Questions as well as the contact details of our Support and Integration Teams."
 logo: '/svgs/Premarc.svg'
 layout: 'single'

--- a/content/integrations/accounting and bookkeeping/Snelstart/_index.md
+++ b/content/integrations/accounting and bookkeeping/Snelstart/_index.md
@@ -1,7 +1,7 @@
 ---
 title: "Snelstart"
 weight: 20
-meta_title: "Snelstart - MultiSafepay Support"
+meta_title: "Snelstart - MultiSafepay Docs"
 meta_description: "The MultiSafepay Documentation Center presents all relevant information about our Plugins and API. You can also find support pages for Payment Methods, Tools and General Questions as well as the contact details of our Support and Integration Teams."
 logo: '/svgs/snelstart.svg'
 layout: 'single'

--- a/content/integrations/community/Community integration requirements/_index.md
+++ b/content/integrations/community/Community integration requirements/_index.md
@@ -1,6 +1,6 @@
 ---
 title : "Submit a community integration"
-meta_title: "Submit a community integration"
+meta_title: "Submit a community integration - MultiSafepay Docs"
 layout: 'paymentdetails'
 meta_description: "The MultiSafepay Documentation Center presents all relevant information about our Plugins and API. You can also find support pages for Payment Methods, Tools and General Questions as well as the contact details of our Support and Integration Teams."
 weight: 102

--- a/content/integrations/hosted/lightspeed_app/faq/available-payment-methods-lightspeed.md
+++ b/content/integrations/hosted/lightspeed_app/faq/available-payment-methods-lightspeed.md
@@ -1,6 +1,6 @@
 ---
 title : "Available payment methods in Lightspeed"
-meta_title: "Lightspeed plugin - Available payment methods"
+meta_title: "Lightspeed plugin - Available payment methods - MultiSafepay Docs"
 meta_description: "The MultiSafepay Documentation Center presents all relevant information about our Plugins and API. You can also find support pages for Payment Methods, Tools and General Questions as well as the contact details of our Support and Integration Teams."
 
 ---

--- a/content/integrations/hosted/lightspeed_app/faq/change-environment.md
+++ b/content/integrations/hosted/lightspeed_app/faq/change-environment.md
@@ -1,6 +1,6 @@
 ---
 title : "Can I change the API key after installation?"
-meta_title: "Lightspeed plugin - Can I change the API key after installation?"
+meta_title: "Lightspeed plugin - Can I change the API key after installation? - MultiSafepay Docs"
 meta_description: "The MultiSafepay Documentation Center presents all relevant information about our Plugins and API. You can also find support pages for Payment Methods, Tools and General Questions as well as the contact details of our Support and Integration Teams."
 ---
 

--- a/content/integrations/hosted/lightspeed_app/faq/disable-payment-methods.md
+++ b/content/integrations/hosted/lightspeed_app/faq/disable-payment-methods.md
@@ -1,6 +1,6 @@
 ---
 title : "Can I disable payment methods?"
-meta_title: "Lightspeed plugin - Can I disable payment methods?"
+meta_title: "Lightspeed plugin - Can I disable payment methods? - MultiSafepay Docs"
 meta_description: "The MultiSafepay Documentation Center presents all relevant information about our Plugins and API. You can also find support pages for Payment Methods, Tools and General Questions as well as the contact details of our Support and Integration Teams."
 ---
 

--- a/content/integrations/hosted/lightspeed_app/faq/inline-buy-button.md
+++ b/content/integrations/hosted/lightspeed_app/faq/inline-buy-button.md
@@ -1,6 +1,6 @@
 ---
 title : "Can I add a buy button near the payment methods?"
-meta_title: "Lightspeed plugin - Can I add a buy button near the payment methods?"
+meta_title: "Lightspeed plugin - Can I add a buy button near the payment methods? - MultiSafepay Docs"
 meta_description: "The MultiSafepay Documentation Center presents all relevant information about our Plugins and API. You can also find support pages for Payment Methods, Tools and General Questions as well as the contact details of our Support and Integration Teams."
 ---
 

--- a/content/integrations/hosted/lightspeed_app/faq/inline-news-letter.md
+++ b/content/integrations/hosted/lightspeed_app/faq/inline-news-letter.md
@@ -1,6 +1,6 @@
 ---
 title : "Can I show the newsletter signup in near the payment methods?"
-meta_title: "Lightspeed plugin - Can I show the newsletter signup in near the payment methods?"
+meta_title: "Lightspeed plugin - Can I show the newsletter signup in near the payment methods? - MultiSafepay Docs"
 meta_description: "The MultiSafepay Documentation Center presents all relevant information about our Plugins and API. You can also find support pages for Payment Methods, Tools and General Questions as well as the contact details of our Support and Integration Teams."
 ---
 

--- a/content/integrations/hosted/lightspeed_app/faq/lightspeed-orderid.md
+++ b/content/integrations/hosted/lightspeed_app/faq/lightspeed-orderid.md
@@ -1,6 +1,6 @@
 ---
 title: "How do I synchronise a generated payment link with Lightspeed?"
-meta_title: "Lightspeed plugin - How do I synchronise a generated payment link with Lightspeed?"
+meta_title: "Lightspeed plugin - How do I synchronise a generated payment link with Lightspeed? - MultiSafepay Docs"
 meta_description: "The MultiSafepay Documentation Center presents all relevant information about our Plugins and API. You can also find support pages for Payment Methods, Tools and General Questions as well as the contact details of our Support and Integration Teams."
 ---
 

--- a/content/integrations/hosted/lightspeed_app/faq/maximal-order-amount.md
+++ b/content/integrations/hosted/lightspeed_app/faq/maximal-order-amount.md
@@ -1,6 +1,6 @@
 ---
 title : "Can I set a maximun order value for a payment method to show up?"
-meta_title: "Lightspeed plugin - Can I set a maximun order value for a payment method to show up?"
+meta_title: "Lightspeed plugin - Can I set a maximun order value for a payment method to show up? - MultiSafepay Docs"
 meta_description: "The MultiSafepay Documentation Center presents all relevant information about our Plugins and API. You can also find support pages for Payment Methods, Tools and General Questions as well as the contact details of our Support and Integration Teams."
 ---
 Yes, you can change the maximum order amount for a payment method to be shown in the checkout. To do so, you have to open the payment method in the _Payment methods ordering_ list by clicking on the "+" sign. Then you need to enter an amount in EUR cents into the maximum field. If you do not want a maximum amount enter “-1”.

--- a/content/integrations/hosted/lightspeed_app/faq/migrate-to-app.md
+++ b/content/integrations/hosted/lightspeed_app/faq/migrate-to-app.md
@@ -1,6 +1,6 @@
 ---
 title : "Can I upgrade to the new app?"
-meta_title: "Lightspeed plugin - Can I upgrade to the new app?"
+meta_title: "Lightspeed plugin - Can I upgrade to the new app? - MultiSafepay Docs"
 meta_description: "The MultiSafepay Documentation Center presents all relevant information about our Plugins and API. You can also find support pages for Payment Methods, Tools and General Questions as well as the contact details of our Support and Integration Teams."
 ---
 

--- a/content/integrations/hosted/lightspeed_app/faq/minimal-order-amount.md
+++ b/content/integrations/hosted/lightspeed_app/faq/minimal-order-amount.md
@@ -1,6 +1,6 @@
 ---
 title : "Can I set a minimal order value for a payment method to show up?"
-meta_title: "Lightspeed plugin - Minimal order value for a payment method"
+meta_title: "Lightspeed plugin - Minimal order value for a payment method - MultiSafepay Docs"
 meta_description: "The MultiSafepay Documentation Center presents all relevant information about our Plugins and API. You can also find support pages for Payment Methods, Tools and General Questions as well as the contact details of our Support and Integration Teams."
 ---
 

--- a/content/integrations/hosted/lightspeed_app/faq/order-payment-methods.md
+++ b/content/integrations/hosted/lightspeed_app/faq/order-payment-methods.md
@@ -1,6 +1,6 @@
 ---
 title : "Can I order the payment methods?"
-meta_title: "Lightspeed plugin - Can I order the payment methods?"
+meta_title: "Lightspeed plugin - Can I order the payment methods? - MultiSafepay Docs"
 meta_description: "The MultiSafepay Documentation Center presents all relevant information about our Plugins and API. You can also find support pages for Payment Methods, Tools and General Questions as well as the contact details of our Support and Integration Teams."
 ---
 

--- a/content/integrations/hosted/lightspeed_app/faq/refunding-lightspeed.md
+++ b/content/integrations/hosted/lightspeed_app/faq/refunding-lightspeed.md
@@ -1,6 +1,6 @@
 ---
 title : "Can I refund orders?"
-meta_title: "Lightspeed plugin - Can I refund orders?"
+meta_title: "Lightspeed plugin - Can I refund orders? - MultiSafepay Docs"
 meta_description: "The MultiSafepay Documentation Center presents all relevant information about our Plugins and API. You can also find support pages for Payment Methods, Tools and General Questions as well as the contact details of our Support and Integration Teams."
 ---
 

--- a/content/integrations/hosted/lightspeed_app/faq/shop_id.md
+++ b/content/integrations/hosted/lightspeed_app/faq/shop_id.md
@@ -1,6 +1,6 @@
 ---
 title : "Where can I find my shop ID?"
-meta_title: "Lightspeed plugin - Where can I find my shop ID?"
+meta_title: "Lightspeed plugin - Where can I find my shop ID? - MultiSafepay Docs"
 meta_description: "The MultiSafepay Documentation Center presents all relevant information about our Plugins and API. You can also find support pages for Payment Methods, Tools and General Questions as well as the contact details of our Support and Integration Teams."
 ---
 1. Log into the /admin area of you webshop app

--- a/content/payment-methods/billing-suite/in3/_index.md
+++ b/content/payment-methods/billing-suite/in3/_index.md
@@ -1,7 +1,7 @@
 ---
 title: 'in3'
 weight: 180
-meta_title: "Payment methods in3 - MultiSafepay Documentation Center"
+meta_title: "Payment methods in3 - MultiSafepay Documentation Center - MultiSafepay Docs"
 meta_description: "The MultiSafepay Documentation Center presents all relevant information about our Plugins and API. You can also find support pages for Payment Methods, Tools and General Questions as well as the contact details of our Support and Integration Teams."
 layout: 'paymentdetail'
 logo: '/svgs/in3.svg' 

--- a/content/payment-methods/billing-suite/in3/activate-in3.md
+++ b/content/payment-methods/billing-suite/in3/activate-in3.md
@@ -1,7 +1,7 @@
 ---
 title: "How to activate in3"
 weight: 22
-meta_title: "in3, How to activate it - MultiSafepay Support"
+meta_title: "in3, How to activate it - MultiSafepay Docs"
 meta_description: "The MultiSafepay Documentation Center presents all relevant information about our Plugins and API. You can also find support pages for Payment Methods, Tools and General Questions as well as the contact details of our Support and Integration Teams."
 read_more: '.'
 ---

--- a/content/payment-methods/billing-suite/in3/how-does-in3-work.md
+++ b/content/payment-methods/billing-suite/in3/how-does-in3-work.md
@@ -1,7 +1,7 @@
 ---
 title: "in3, How it works"
 weight: 21
-meta_title: "in3, How it works - MultiSafepay Support"
+meta_title: "in3, How it works - MultiSafepay Docs"
 meta_description: "The MultiSafepay Documentation Center presents all relevant information about our Plugins and API. You can also find support pages for Payment Methods, Tools and General Questions as well as the contact details of our Support and Integration Teams."
 read_more: '.'
 ---

--- a/content/payment-methods/billing-suite/in3/in3-testing.md
+++ b/content/payment-methods/billing-suite/in3/in3-testing.md
@@ -1,7 +1,7 @@
 ---
 title: "Testing with in3"
 weight: 22
-meta_title: "in3, Testing - MultiSafepay Support"
+meta_title: "in3, Testing - MultiSafepay Docs"
 meta_description: "The MultiSafepay Documentation Center presents all relevant information about our Plugins and API. You can also find support pages for Payment Methods, Tools and General Questions as well as the contact details of our Support and Integration Teams."
 read_more: '.'
 ---

--- a/content/payment-methods/billing-suite/in3/refund-in3.md
+++ b/content/payment-methods/billing-suite/in3/refund-in3.md
@@ -1,7 +1,7 @@
 ---
 title: "How to refund an in3 transaction"
 weight: 23
-meta_title: "in3, how to refund a transaction - MultiSafepay Support"
+meta_title: "in3, how to refund a transaction - MultiSafepay Docs"
 meta_description: "The MultiSafepay Documentation Center presents all relevant information about our Plugins and API. You can also find support pages for Payment Methods, Tools and General Questions as well as the contact details of our Support and Integration Teams."
 read_more: '.'
 ---

--- a/content/payment-methods/billing-suite/in3/what-is-in3.md
+++ b/content/payment-methods/billing-suite/in3/what-is-in3.md
@@ -1,7 +1,7 @@
 ---
 title: "in3, What it is"
 weight: 20
-meta_title: "in3, What it is - MultiSafepay Support"
+meta_title: "in3, What it is - MultiSafepay Docs"
 meta_description: "The MultiSafepay Documentation Center presents all relevant information about our Plugins and API. You can also find support pages for Payment Methods, Tools and General Questions as well as the contact details of our Support and Integration Teams."
 read_more: '.'
 ---

--- a/content/tools/reports/N-codes.md
+++ b/content/tools/reports/N-codes.md
@@ -1,7 +1,7 @@
 ---
 title: "N-Codes and description"
 weight: 
-meta_title: "What are N-Codes"
+meta_title: "What are N-Codes - MultiSafepay Docs"
 meta_description: "The MultiSafepay Documentation Center presents all relevant information about our Plugins and API. You can also find support pages for Payment Methods, Tools and General Questions as well as the contact details of our Support and Integration Teams."
 read_more: '.'
 ---


### PR DESCRIPTION
Changed 27 more metatitles using the regex expression:
meta_title:(?!.*MultiSafepay Docs)
to find all meta_title suffixes that didn't match "- MultiSafepay Docs"
It seems like homepage is last page with different suffix as it uses:
"| MultiSafepay Docs". I can't find where this title is generated as it's
not listed in a markdown file, but probably a hugo config.

Signed-off-by: Kris-MultiSafepay <kris.stallenberg@multisafepay.com>

### Basic
- We only accept documentation that is proved to work on our LIVE API
- At least 1 approval is needed before pull requests can be merged
- The article must match our Synonym word list. For external commits, a MultiSafepay employee will check
- US English must be applied
- Use bullets for numerations where the sort order doesn't matter. For chronological order, use numbers. This does not apply to changelogs
- Set link on email address.

### Text style
- Paths are written like: _Configuration → System → Plugin → MultiSafepay_
- Use single quotation marks in your Markdown code (example title: 'Title of the article')
- Use Italics for buttons, clicks, paths, etc. Do mind to close the italics before the end of a sentence followed by a period
- Numerations / bullets are punctuated with a period at the end of the numerations / bullets.
- Periods should be excluded for sentences that finish in an e-mail address (e.g. "..contact us at <example@example.com> "  )

### Images
- Screenshot recomended sizes: Width: 820px - Height: auto