### PR TITLE
DOCS-1732: Uniform meta_titles

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -1,5 +1,6 @@
 ---
 title: 'MultiSafepay Documentation Center'
+meta_title: 'Home - MultiSafepay Docs'
 breadcrumb_title: "Home"
 meta_description: "The MultiSafepay Documentation Center presents all relevant information about our Plugins and API. You can also find support pages for Payment Methods, Tools and General Questions as well as the contact details of our Support and Integration Teams."
 data:

--- a/content/faq/_index.md
+++ b/content/faq/_index.md
@@ -1,8 +1,8 @@
 ---
 title: 'Frequently Asked Questions'
+meta_title: 'FAQ - MultiSafepay Docs'
 breadcrumb_title: 'FAQ'
 layout: 'block'
-meta_title: "All FAQ - MultiSafepay Docs"
 meta_description: "The MultiSafepay Documentation Center presents all relevant information about our Plugins and API. You can also find support pages for Payment Methods, Tools and General Questions as well as the contact details of our Support and Integration Teams."
 logo: '/svgs/FAQ.svg'
 short_description: 'Do you have a question and are you unable find the answer? View this page for answers to the most common questions.'

--- a/content/how-to-find-us/_index.md
+++ b/content/how-to-find-us/_index.md
@@ -1,7 +1,7 @@
 ---
 title: 'How to find us'
+meta_title: 'How to find us - MultiSafepay Docs'
 tags: 'hidden'
 weight: 64
-meta_title: "Route to our Amsterdam Office - MultiSafepay Docs"
 meta_description: "The MultiSafepay Documentation Center presents all relevant information about our Plugins and API. You can also find support pages for Payment Methods, Tools and General Questions as well as the contact details of our Support and Integration Teams."
 ---

--- a/content/integration-team/_index.md
+++ b/content/integration-team/_index.md
@@ -1,9 +1,9 @@
 ---
 title: 'Integration Team'
+meta_title: 'Integration Team - MultiSafepay Docs'
 breadcrumb_title: 'Integration Team'
 layout: 'Integration Team'
 tags: 'hidden'
 logo: '/svgs/Integrations.svg'
-short_description: 'lorem ipsumlorem ipsumlorem ipsumlorem ipsumlorem ipsumlorem ipsumlorem ipsum'
-weight: 100
+meta_description: "The MultiSafepay Documentation Center presents all relevant information about our Plugins and API. You can also find support pages for Payment Methods, Tools and General Questions as well as the contact details of our Support and Integration Teams."
 ---

--- a/content/payment-methods/_index.md
+++ b/content/payment-methods/_index.md
@@ -1,5 +1,6 @@
 ---
 title: 'Payment Methods'
+meta_title: 'Payment Methods - MultiSafepay Docs'
 breadcrumb_title: 'Payment Methods'
 layout: 'block'
 meta_description: "The MultiSafepay Documentation Center presents all relevant information about our Plugins and API. You can also find support pages for Payment Methods, Tools and General Questions as well as the contact details of our Support and Integration Teams."

--- a/content/tools/_index.md
+++ b/content/tools/_index.md
@@ -1,8 +1,8 @@
 ---
 title: 'Tools'
+meta_title: 'Tools - MultiSafepay Docs'
 breadcrumb_title: 'Tools'
 layout: 'block'
-meta_title: "Tools support - MultiSafepay Docs"
 meta_description: "The MultiSafepay Documentation Center presents all relevant information about our Plugins and API. You can also find support pages for Payment Methods, Tools and General Questions as well as the contact details of our Support and Integration Teams."
 logo: '/svgs/Tools.svg'
 short_description: 'Read more about special features and functionalities that the MultiSafepay service has to offer.'


### PR DESCRIPTION
Some _index pages have missing meta_title fields, causing automatically
generated html titles with suffix "| MultiSafepay". To prevent this,
explicit meta_titles must be created.

Signed-off-by: Kris-MultiSafepay <kris.stallenberg@multisafepay.com>

### Basic
- We only accept documentation that is proved to work on our LIVE API
- At least 1 approval is needed before pull requests can be merged
- The article must match our Synonym word list. For external commits, a MultiSafepay employee will check
- US English must be applied
- Use bullets for numerations where the sort order doesn't matter. For chronological order, use numbers. This does not apply to changelogs
- Set link on email address.

### Text style
- Paths are written like: _Configuration → System → Plugin → MultiSafepay_
- Use single quotation marks in your Markdown code (example title: 'Title of the article')
- Use Italics for buttons, clicks, paths, etc. Do mind to close the italics before the end of a sentence followed by a period
- Numerations / bullets are punctuated with a period at the end of the numerations / bullets.
- Periods should be excluded for sentences that finish in an e-mail address (e.g. "..contact us at <example@example.com> "  )

### Images
- Screenshot recomended sizes: Width: 820px - Height: auto