### PR TITLE
DOCS-1759: Fix in3 meta_title

### DIFF
--- a/content/payment-methods/billing-suite/in3/_index.md
+++ b/content/payment-methods/billing-suite/in3/_index.md
@@ -1,7 +1,7 @@
 ---
 title: 'in3'
 weight: 180
-meta_title: "Payment methods in3 - MultiSafepay Documentation Center - MultiSafepay Docs"
+meta_title: "Payment methods in3 - MultiSafepay Docs"
 meta_description: "The MultiSafepay Documentation Center presents all relevant information about our Plugins and API. You can also find support pages for Payment Methods, Tools and General Questions as well as the contact details of our Support and Integration Teams."
 layout: 'paymentdetail'
 logo: '/svgs/in3.svg' 


### PR DESCRIPTION
Metatitle contained double suffix "In3 - MultiSafepay Documentation Center -
MultiSafepay Docs". This was generated in bulk rename. Delete first suffix.

Signed-off-by: Kris-MultiSafepay <kris.stallenberg@multisafepay.com>

### Basic
- We only accept documentation that is proved to work on our LIVE API
- At least 1 approval is needed before pull requests can be merged
- The article must match our Synonym word list. For external commits, a MultiSafepay employee will check
- US English must be applied
- Use bullets for numerations where the sort order doesn't matter. For chronological order, use numbers. This does not apply to changelogs
- Set link on email address.

### Text style
- Paths are written like: _Configuration → System → Plugin → MultiSafepay_
- Use single quotation marks in your Markdown code (example title: 'Title of the article')
- Use Italics for buttons, clicks, paths, etc. Do mind to close the italics before the end of a sentence followed by a period
- Numerations / bullets are punctuated with a period at the end of the numerations / bullets.
- Periods should be excluded for sentences that finish in an e-mail address (e.g. "..contact us at <example@example.com> "  )

### Images
- Screenshot recomended sizes: Width: 820px - Height: auto