### PR TITLE
DOCS-1426b: added_blank_space

### DIFF
--- a/content/faq/api/how-does-the-notification-url-work.md
+++ b/content/faq/api/how-does-the-notification-url-work.md
@@ -83,6 +83,7 @@ The security requirement you must implement is to always validate the payload so
 
 ### Response
 As response, MultiSafepay expects an empty page with one of the following:
+
 * _OK_ on the first two characters of the body of the response
 * _MULTISAFEPAY_OK_ anywhere in the body of the response
 


### PR DESCRIPTION
### Basic
- We only accept documentation that is proved to work on our LIVE API
- At least 1 approval is needed before pull requests can be merged
- The article must match our Synonym word list. For external commits, a MultiSafepay employee will check
- US English must be applied
- Use bullets for numerations where the sort order doesn't matter. For chronological order, use numbers. This does not apply to changelogs
- Set link on email address.

### Text style
- Paths are written like: _Configuration → System → Plugin → MultiSafepay_
- Use single quotation marks in your Markdown code (example title: 'Title of the article')
- Use Italics for buttons, clicks, paths, etc. Do mind to close the italics before the end of a sentence followed by a period
- Numerations / bullets are punctuated with a period at the end of the numerations / bullets.
- Periods should be excluded for sentences that finish in an e-mail address (e.g. "..contact us at <example@example.com> "  )

### Images
- Screenshot recomended sizes: Width: 820px - Height: auto