### PR TITLE
DOCS-1771: Fix SCA Diagram

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -145,7 +145,7 @@ div.msp-app-text p:last-child {
 
 @media screen and (max-width: 991px){
     .large {display: none;}
-    .mobile{display: block;}
+    .mobile {display: block;}
 }
 
 /*********** FOOTER ***********/


### PR DESCRIPTION
Problem lies in CSS. The updated CSS is in github repo, but not on server.
Hence the responsive rules do not apply. Made tiny typo fix to see if this will
override main.css on server.

Signed-off-by: Kris-MultiSafepay <kris.stallenberg@multisafepay.com>

### Basic
- We only accept documentation that is proved to work on our LIVE API
- At least 1 approval is needed before pull requests can be merged
- The article must match our Synonym word list. For external commits, a MultiSafepay employee will check
- US English must be applied
- Use bullets for numerations where the sort order doesn't matter. For chronological order, use numbers. This does not apply to changelogs
- Set link on email address.

### Text style
- Paths are written like: _Configuration → System → Plugin → MultiSafepay_
- Use single quotation marks in your Markdown code (example title: 'Title of the article')
- Use Italics for buttons, clicks, paths, etc. Do mind to close the italics before the end of a sentence followed by a period
- Numerations / bullets are punctuated with a period at the end of the numerations / bullets.
- Periods should be excluded for sentences that finish in an e-mail address (e.g. "..contact us at <example@example.com> "  )

### Images
- Screenshot recomended sizes: Width: 820px - Height: auto