### PR TITLE
DOCS-473: Add markdown-link-check to Github Actions

### DIFF
--- a/.github/mlc_config.json
+++ b/.github/mlc_config.json
@@ -1,0 +1,8 @@
+{
+    "replacementPatterns": [
+        {
+            "pattern": "^/",
+	    "replacement": "https://docs.multisafepay.com/"
+        }
+    ]
+}

--- a/.github/mlc_config.json
+++ b/.github/mlc_config.json
@@ -2,7 +2,13 @@
     "replacementPatterns": [
         {
             "pattern": "^/",
-	    "replacement": "https://docs.multisafepay.com/"
+	        "replacement": "https://docs.multisafepay.com/"
+        },
+        {
+            "pattern": "&quot;",
+            "replacement": ""
         }
-    ]
+    ],
+    "retryOn429": true,
+    "aliveStatusCodes": [999]
 }

--- a/.github/mlc_config.json
+++ b/.github/mlc_config.json
@@ -9,6 +9,11 @@
             "replacement": ""
         }
     ],
+    "ignorePatterns": [
+        {
+          "pattern": "^https://www.example.com"
+        }
+      ],
     "retryOn429": true,
     "aliveStatusCodes": [200, 206, 999]
 }

--- a/.github/mlc_config.json
+++ b/.github/mlc_config.json
@@ -10,5 +10,5 @@
         }
     ],
     "retryOn429": true,
-    "aliveStatusCodes": [999]
+    "aliveStatusCodes": [200, 206, 999]
 }

--- a/.github/workflows/markdown-link-check.yml
+++ b/.github/workflows/markdown-link-check.yml
@@ -8,3 +8,6 @@ jobs:
     steps:
     - uses: actions/checkout@master
     - uses: Kris-MultiSafepay/github-action-markdown-link-check@v1
+      with:
+        use-quiet-mode: 'yes'
+        config-file: 'mlc_config.json'

--- a/.github/workflows/markdown-link-check.yml
+++ b/.github/workflows/markdown-link-check.yml
@@ -7,4 +7,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
-    - uses: gaurav-nelson/github-action-markdown-link-check@v1
+    - uses: Kris-MultiSafepay/github-action-markdown-link-check@v1

--- a/.github/workflows/markdown-link-check.yml
+++ b/.github/workflows/markdown-link-check.yml
@@ -10,4 +10,4 @@ jobs:
     - uses: Kris-MultiSafepay/github-action-markdown-link-check@v1
       with:
         use-quiet-mode: 'yes'
-        config-file: 'mlc_config.json'
+        config-file: './.github/mlc_config.json'

--- a/.github/workflows/markdown-link-check.yml
+++ b/.github/workflows/markdown-link-check.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
-    - uses: Kris-MultiSafepay/github-action-markdown-link-check@v1
+    - uses: gaurav-nelson/github-action-markdown-link-check@v1
       with:
         use-quiet-mode: 'yes'
         config-file: './.github/mlc_config.json'

--- a/.github/workflows/markdown-link-check.yml
+++ b/.github/workflows/markdown-link-check.yml
@@ -1,0 +1,10 @@
+name: Check Markdown links
+
+on: [pull_request]
+
+jobs:
+  markdown-link-check:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - uses: gaurav-nelson/github-action-markdown-link-check@v1


### PR DESCRIPTION
Signed-off-by: Kris-MultiSafepay <kris.stallenberg@multisafepay.com>

### Basic
- We only accept documentation that is proved to work on our LIVE API
- At least 1 approval is needed before pull requests can be merged
- The article must match our Synonym word list. For external commits, a MultiSafepay employee will check
- US English must be applied
- Use bullets for numerations where the sort order doesn't matter. For chronological order, use numbers. This does not apply to changelogs
- Set link on email address.

### Text style
- Paths are written like: _Configuration → System → Plugin → MultiSafepay_
- Use single quotation marks in your Markdown code (example title: 'Title of the article')
- Use Italics for buttons, clicks, paths, etc. Do mind to close the italics before the end of a sentence followed by a period
- Numerations / bullets are punctuated with a period at the end of the numerations / bullets.
- Periods should be excluded for sentences that finish in an e-mail address (e.g. "..contact us at <example@example.com> "  )

### Images
- Screenshot recomended sizes: Width: 820px - Height: auto