### PR TITLE
DOCS: Add payment_link variable information for Magento 2 e-mail templates

### DIFF
--- a/content/integrations/plugins/magento2/faq/payment-links-in-order-confirmation-for-backend-orders.md
+++ b/content/integrations/plugins/magento2/faq/payment-links-in-order-confirmation-for-backend-orders.md
@@ -3,31 +3,37 @@ title : "Payment link in order confirmation email for backend orders"
 meta_title: "Magento 2 plugin FAQ - Payment links - MultiSafepay Docs"
 meta_description: "The MultiSafepay Documentation Center presents all relevant information about our Plugins and API. You can also find support pages for payment methods, tools and general questions as well as the contact details of our Support and Integration Teams."
 layout: "faqdetail"
-summary: "As of version 1.7.0, we have added a feature to include the payment link in the order confirmation mail. This feature is customizable and can be changed to your liking."
+summary: "We have added a feature to include the payment link in the order confirmation mail. This feature is customizable and can be changed to your liking."
 read_more: "."
 aliases:
     - /magento2/faq/payment-links-in-order-confirmation-for-backend-orders
 ---
 
-As of version 1.7.0, we have added a feature to include the payment link in the order confirmation mail. This feature is customizable and can be changed to your liking. This feature can be implemented by the following steps:
+We have added a feature to include the payment link in the order confirmation mail. This feature is customizable and can be changed to your liking. This feature can be implemented by the following steps:
 
-1. Log in to your Magento backend. Check how we do it [here](/integrations/plugins/magento2/old/) in step 5. 
+1. Login into your Magento backend. Check how we do it [here](/integrations/plugins/magento2/old/) in step 3. 
 2. Go to _Marketing_ -> _Email Templates_
 3. Add a template (import from _new order_)
-4. Add this sample code the template
+4. Add this sample code to the template
 </br>
 `{{depend order.getPayment().getAdditionalInformation('payment_link')}}`
 `<a href="{{var order.getPayment().getAdditionalInformation('payment_link')}}">Pay now with {{var order.getPayment().getAdditionalInformation('method_title')}}</a>`
 `{{/depend}}`\
 </br>\
-The email template syntax is different for Magento 2.3.4+. For these versions, you can add this sample code instead
+The email template syntax is different for Magento 2.3.4+. For these versions you can add this sample code instead
 </br>
 `{{depend order.payment.additional_information.payment_link}}`
 `<a href="{{var order.payment.additional_information.payment_link}}">Pay now with {{var order.payment.additional_information.method_title}}</a>`
 `{{/depend}}`\
 </br>
-If you only want to send the payment link in order confirmation e-mails for backend orders, we have added the payment_link variable that can be used in the e-mail template as following:
-'<a href="{{var payment_link}}">Pay now with {{var order.payment.additional_information.method_title}}</a>'
+
+There is also a 'payment_link' variable that you can use in e-mail templates for order confirmation e-mails that were created in the backend of Magento. This variable is not available for orders that are created in the frontend. With a simple 'if/else' statement in the e-mail template you can add logic to only add the payment link to order confirmation e-mails for orders that are created in the backend. For the frontend orders you can show something else, like for example only the payment method title:
+
+`{{if payment_link}}`\
+`<a href="{{var payment_link}}">Pay now with {{var order.payment.additional_information.method_title}}</a>`\
+`{{else}}`\
+`<p>{{var order.payment.additional_information.method_title}}</p>`\
+`{{/if}}`\
 
 5. Go to _Stores -> Configuration → Sales → Sales Emails_
 6. Change the "New Order Confirmation Template" with your template

--- a/content/integrations/plugins/magento2/faq/payment-links-in-order-confirmation-for-backend-orders.md
+++ b/content/integrations/plugins/magento2/faq/payment-links-in-order-confirmation-for-backend-orders.md
@@ -11,10 +11,10 @@ aliases:
 
 We have added a feature to include the payment link in the order confirmation mail. This feature is customizable and can be changed to your liking. This feature can be implemented by the following steps:
 
-1. Login into your Magento backend 
+1. Log in to your Magento backend 
 2. Go to _Marketing_ -> _Email Templates_
 3. Add a template (import from _new order_)
-4. Add this sample code to the template
+4. Add this code snippet to the template
 </br>
 `{{depend order.getPayment().getAdditionalInformation('payment_link')}}`
 `<a href="{{var order.getPayment().getAdditionalInformation('payment_link')}}">Pay now with {{var order.getPayment().getAdditionalInformation('method_title')}}</a>`
@@ -27,7 +27,7 @@ The email template syntax is different for Magento 2.3.4+. For these versions yo
 `{{/depend}}`\
 </br>
 
-There is also a 'payment_link' variable that you can use in e-mail templates for order confirmation e-mails that were created in the backend of Magento. This variable is not available for orders that are created in the frontend. With a simple 'if/else' statement in the e-mail template you can add logic to only add the payment link to order confirmation e-mails for orders that are created in the backend. For the frontend orders you can show something else, like for example only the payment method title:
+There is also a 'payment_link' variable that you can use in e-mail templates for order confirmation e-mails created in the backend of Magento. This variable is not available for orders that are created in the frontend. With a simple 'if/else' statement in the e-mail template, you can add logic to only add the payment link to order confirmation e-mails for orders created in the backend. For orders created in the frontend, you can show something else, for example, only the payment method title:
 
 `{{if payment_link}}`\
 `<a href="{{var payment_link}}">Pay now with {{var order.payment.additional_information.method_title}}</a>`\

--- a/content/integrations/plugins/magento2/faq/payment-links-in-order-confirmation-for-backend-orders.md
+++ b/content/integrations/plugins/magento2/faq/payment-links-in-order-confirmation-for-backend-orders.md
@@ -11,7 +11,7 @@ aliases:
 
 We have added a feature to include the payment link in the order confirmation mail. This feature is customizable and can be changed to your liking. This feature can be implemented by the following steps:
 
-1. Login into your Magento backend. Check how we do it [here](/integrations/plugins/magento2/old/) in step 3. 
+1. Login into your Magento backend 
 2. Go to _Marketing_ -> _Email Templates_
 3. Add a template (import from _new order_)
 4. Add this sample code to the template


### PR DESCRIPTION
### Basic
- We only accept documentation that is proved to work on our LIVE API
- At least 1 approval is needed before pull requests can be merged
- The article must match our Synonym word list. For external commits, a MultiSafepay employee will check
- US English must be applied
- Use bullets for numerations where the sort order doesn't matter. For chronological order, use numbers. This does not apply to changelogs
- Set link on email address.

### Text style
- Paths are written like: _Configuration → System → Plugin → MultiSafepay_
- Use single quotation marks in your Markdown code (example title: 'Title of the article')
- Use Italics for buttons, clicks, paths, etc. Do mind to close the italics before the end of a sentence followed by a period
- Numerations / bullets are punctuated with a period at the end of the numerations / bullets.
- Periods should be excluded for sentences that finish in an e-mail address (e.g. "..contact us at <example@example.com> "  )

### Images
- Screenshot recomended sizes: Width: 820px - Height: auto