### PR TITLE
DOCS-2064: Apply copy code button throughout docs

### DIFF
--- a/content/integrations/plugins/magento2/manual.md
+++ b/content/integrations/plugins/magento2/manual.md
@@ -1,6 +1,7 @@
 ---
 title : "MultiSafepay Magento 2 installation & configuration manual"
 meta_title: "Magento 2 plugin manual - MultiSafepay Docs"
+layout: 'single'
 meta_description: "The MultiSafepay Documentation Center presents all relevant information about our Plugins and API. You can also find support pages for payment methods, tools and general questions as well as the contact details of our Support and Integration Teams."
 aliases:
     - /support-tab/magento2/manual
@@ -59,7 +60,7 @@ For GraphQL support there is a separate module:
 ### 4. Installation
 For merchants, we recommend installing the meta-package via composer:
 
-```shell
+``` 
 composer require multisafepay/magento2
 php bin/magento setup:upgrade
 php bin/magento setup:di:compile
@@ -69,19 +70,19 @@ php bin/magento setup:static-content:deploy
 This will automatically install all the modules that are necessary to get started.
 
 After installing, the following command can be used in the Magento 2 root directory to enable all the modules:
-```shell
+```
 ./bin/magento module:enable `./bin/magento module:status | grep MultiSafepay_`
 ```
 
 #### 4.1 Stock handling
 
 If you have disabled MSI inside Magento 2, then you can use the following command to disable the MultiSafepay MSI module:
-```shell
+```
 php bin/magento module:disable MultiSafepay_ConnectMSI
 ```
 
 If you have a Magento 2 installation with MSI enabled, you can use the following command to disable the MultiSafepay CatalogInventory module instead:
-```shell
+```
 php bin/magento module:disable MultiSafepay_ConnectCatalogInventory
 ```
 
@@ -107,7 +108,7 @@ You have installed and configured the plugin successfully. If you have any quest
 
 ### 7. Updates 
 Run the following commands via the CLI:
-```shell
+```
 composer update multisafepay/magento2 --with-dependencies
 php bin/magento setup:upgrade
 php bin/magento setup:di:compile

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -156,6 +156,13 @@
         });
     </script>
     <!--End AnchorJS -->	
+
+    <!-- Insert copy-code-button on every page with <pre> tags -->
+    {{ if (findRE "<pre" .Content 1) }}
+        <script src="/js/copy-code-button.js"></script>
+    {{ end }}
+    <!-- End copy-code-button -->
+
     <script src="{{ .Site.BaseURL }}js/bootstrap.min.js"></script>
     <script src="https://addsearch.com/js/?key=62b1ea328472f530ca8688670ac54b30"></script>
 </body>

--- a/layouts/_default/single-old-button.html
+++ b/layouts/_default/single-old-button.html
@@ -82,6 +82,10 @@
 {{ partial "newsletter" (dict "context" . "title" .Page.Params.newsletter) }}
 {{end}}
 
+    <!-- Insert copy-code-button because baseofhtml doesn't suffice for some reason -->
+        <script src="/js/copy-code-button.js"></script>
+    <!-- End copy-code-button -->
+
 <script src="{{ "/js/scroll-offset.js" | relURL }}"></script>
 <script src="{{ .Site.BaseURL }}js/tocbot.min.js"></script>
 <script src="{{ .Site.BaseURL }}js/scroll-menu.js"></script>

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -85,7 +85,4 @@
 <script src="{{ "/js/scroll-offset.js" | relURL }}"></script>
 <script src="{{ .Site.BaseURL }}js/tocbot.min.js"></script>
 <script src="{{ .Site.BaseURL }}js/scroll-menu.js"></script>
-{{ if (findRE "<pre" .Content 1) }}
-    <script src="/js/copy-code-button.js"></script>
-{{ end }}
 {{ end }}


### PR DESCRIPTION
### Basic
- We only accept documentation that is proved to work on our LIVE API
- At least 1 approval is needed before pull requests can be merged
- The article must match our Synonym word list. For external commits, a MultiSafepay employee will check
- US English must be applied
- Use bullets for numerations where the sort order doesn't matter. For chronological order, use numbers. This does not apply to changelogs
- Set link on email address.

### Text style
- Paths are written like: _Configuration → System → Plugin → MultiSafepay_
- Use single quotation marks in your Markdown code (example title: 'Title of the article')
- Use Italics for buttons, clicks, paths, etc. Do mind to close the italics before the end of a sentence followed by a period
- Numerations / bullets are punctuated with a period at the end of the numerations / bullets.
- Periods should be excluded for sentences that finish in an e-mail address (e.g. "..contact us at <example@example.com> "  )

### Images
- Screenshot recomended sizes: Width: 820px - Height: auto

### Aliases
- When renaming or deleting a page, add an alias of the renamed or deleted page to the page users should be redirected to instead. This prevents external links to return 404 errors. Check the [Hugo Documentation](https://gohugo.io/content-management/urls/#aliases) for more information.
