### PR TITLE
DOCS-2098: Add preOrder documentation to Credit Card Component

### DIFF
--- a/content/tools/credit-card-component/_index.md
+++ b/content/tools/credit-card-component/_index.md
@@ -83,21 +83,44 @@ PaymentComponent.init('payment', {
 ```
 {{< br >}}
 
-### 2. Styling template
+### 2. Pass preOrder data to the Credit Card Component
 
-The Credit Card Component comes with two styling templates. For a more seamless integration, we recommend to enable our embedded template, the following parameter needs to be added:
+The Credit Card Component requires some initial information about your customer's shopping cart. This information is used to perform validation checks, such as:
+
+- Is the selected payment method compatible with the currency?
+- Is the selected payment method compatible with the order value?
 
 ```
-const configOrder = {
+const preOrder = {
     currency: 'EUR',
-    amount: 100,
+    amount: 10000,
+    customer: {
+        locale: 'EN',
+        country: 'NL',
+        reference: 'Customer123'
+    },
     template : {
         settings: {
             embed_mode: true
         }
+    }
 };
 ```
 {{< br >}}
+
+#### Required variables
+| Key | Value |
+| ---- | ---- |
+| currency | Currency of the order. {{< br >}} **Format:** [ISO-4217](https://en.wikipedia.org/wiki/ISO_4217) |
+| amount | Value of the order. {{< br >}} **Format:** Number without decimal points (e.g., 100EU → `10000`) |
+
+#### Optional variables
+| Key | Value |
+| --- | --- |
+| locale | Your customer's browser language, which is used to set the Credit Card Component's language. {{< br >}} **Format:** [ISO-3166-2](https://en.wikipedia.org/wiki/ISO_3166-2) |
+| country | Your customer's country code, which is used to validate the availability of the payment method. {{< br >}} **Format:** [ISO-3166-2](https://en.wikipedia.org/wiki/ISO_3166-2) |]
+| reference | A unique reference to your customer, used in tokenization. {{< br >}} **Format:** string |
+| embed_mode | Embed mode is a template designed to blend in seamlessly with your ecommerce. {{< br >}} **Format:** boolean |
 
 
 ### 3. Place a Test order


### PR DESCRIPTION
### Basic
- We only accept documentation that is proved to work on our LIVE API
- At least 1 approval is needed before pull requests can be merged
- The article must match our Synonym word list. For external commits, a MultiSafepay employee will check
- US English must be applied
- Use bullets for numerations where the sort order doesn't matter. For chronological order, use numbers. This does not apply to changelogs
- Set link on email address.

### Text style
- Paths are written like: _Configuration → System → Plugin → MultiSafepay_
- Use single quotation marks in your Markdown code (example title: 'Title of the article')
- Use Italics for buttons, clicks, paths, etc. Do mind to close the italics before the end of a sentence followed by a period
- Numerations / bullets are punctuated with a period at the end of the numerations / bullets.
- Periods should be excluded for sentences that finish in an e-mail address (e.g. "..contact us at <example@example.com> "  )

### Images
- Screenshot recomended sizes: Width: 820px - Height: auto

### Aliases
- When renaming or deleting a page, add an alias of the renamed or deleted page to the page users should be redirected to instead. This prevents external links to return 404 errors. Check the [Hugo Documentation](https://gohugo.io/content-management/urls/#aliases) for more information.
