### PR TITLE
DOCS-2042: Fix syntax @DUE_DATE@

### DIFF
--- a/content/payment-methods/billing-suite/e-invoicing/how-does-e-invoicing-work.md
+++ b/content/payment-methods/billing-suite/e-invoicing/how-does-e-invoicing-work.md
@@ -30,7 +30,7 @@ Each action needs to created following these steps:
 
 Example plain body:      
 
-```shell  
+``` shell
 Date: @CURRENTDATE@ 
 Order number: @DESCRIPTION@
 
@@ -43,7 +43,7 @@ Thank you for your order at @SITENAME@.
 Details of your order:
 @CONTENT@
 
-We kindly request you to pay the invoice for @ DUE_DATE @.
+We kindly request you to pay the invoice for @DUE_DATE@.
 
 Complete your payment using the payment link below
 @PAYLINK@ 


### PR DESCRIPTION
### Basic
- We only accept documentation that is proved to work on our LIVE API
- At least 1 approval is needed before pull requests can be merged
- The article must match our Synonym word list. For external commits, a MultiSafepay employee will check
- US English must be applied
- Use bullets for numerations where the sort order doesn't matter. For chronological order, use numbers. This does not apply to changelogs
- Set link on email address.

### Text style
- Paths are written like: _Configuration → System → Plugin → MultiSafepay_
- Use single quotation marks in your Markdown code (example title: 'Title of the article')
- Use Italics for buttons, clicks, paths, etc. Do mind to close the italics before the end of a sentence followed by a period
- Numerations / bullets are punctuated with a period at the end of the numerations / bullets.
- Periods should be excluded for sentences that finish in an e-mail address (e.g. "..contact us at <example@example.com> "  )

### Images
- Screenshot recomended sizes: Width: 820px - Height: auto

### Aliases
- When renaming or deleting a page, add an alias of the renamed or deleted page to the page users should be redirected to instead. This prevents external links to return 404 errors. Check the [Hugo Documentation](https://gohugo.io/content-management/urls/#aliases) for more information.
