### PR TITLE
DOCS-2114: Add alias to every ecommerce integration _index and manual

### DIFF
--- a/content/integrations/ecommerce integrations/_index.md
+++ b/content/integrations/ecommerce integrations/_index.md
@@ -7,6 +7,7 @@ meta_description: "The MultiSafepay Documentation Center presents all relevant i
 logo: '/svgs/Plugins.svg'
 short_description: 'Our ready-made solutions for most popular ecommerce platforms'
 weight: 10
-aliases: [/plugins/]
-aliases: [/integrations/plugins/]
+aliases: 
+    - /plugins/
+    - /integrations/plugins/
 ---

--- a/content/integrations/ecommerce integrations/ccvshop/_index.md
+++ b/content/integrations/ecommerce integrations/ccvshop/_index.md
@@ -12,5 +12,8 @@ description_short: "Easily integrate MultiSafepay payment solutions into your CC
 description: "Easily integrate MultiSafepay payment solutions into your CCV Shop with this free app.
 This app is managed by our partner CCV Shop. For support, please contact [CCV Shop](https://www.ccvshop.nl/contact) directly."
 layout: 'single'
-aliases: [/integrations/ccvshop/]
+aliases: 
+    - /plugins/ccvshop
+    - /integrations/plugins/ccvshop
+    - /integrations/ccvshop
 ---

--- a/content/integrations/ecommerce integrations/ccvshop/manual.md
+++ b/content/integrations/ecommerce integrations/ccvshop/manual.md
@@ -2,7 +2,9 @@
 title : "MultiSafepay CCV Shop installation & configuration manual"
 meta_title: "CCV Shop plugin manual - MultiSafepay Docs"
 meta_description: "The MultiSafepay Documentation Center presents all relevant information about our Plugins and API. You can also find support pages for payment methods, tools and general questions as well as the contact details of our Support and Integration Teams."
-aliases: [/integrations/ccvshop/manual/]
+aliases: 
+    - /plugins/ccvshop/manual/
+    - /integrations/plugins/ccvshop/manual/
 ---
 
 ### Introduction

--- a/content/integrations/ecommerce integrations/craftcommerce/_index.md
+++ b/content/integrations/ecommerce integrations/craftcommerce/_index.md
@@ -14,5 +14,9 @@ changelog: https://github.com/MultiSafepay/craft-commerce/blob/master/CHANGELOG.
 layout: 'single'
 manual: "."
 faq: "."
+aliases: 
+    - /plugins/craftcommerce
+    - /integrations/plugins/craftcommerce
+    - /integrations/craftcommerce
 
 ---

--- a/content/integrations/ecommerce integrations/craftcommerce/manual.md
+++ b/content/integrations/ecommerce integrations/craftcommerce/manual.md
@@ -2,6 +2,11 @@
 title : "MultiSafepay Craft Commerce 3 installation & configuration manual"
 meta_title: "Craft Commerce 3 plugin manual - MultiSafepay Docs"
 meta_description: "The MultiSafepay Documentation Center presents all relevant information about our Plugins and API. You can also find support pages for payment methods, tools and general questions as well as the contact details of our Support and Integration Teams."
+aliases: 
+    - /plugins/craftcommerce/manual
+    - /integrations/plugins/craftcommerce/manual
+    - /integrations/craftcommerce/manual
+
 ---
 
 ### Introduction

--- a/content/integrations/ecommerce integrations/cs-cart/_index.md
+++ b/content/integrations/ecommerce integrations/cs-cart/_index.md
@@ -13,5 +13,8 @@ title_short: "CS-Cart"
 layout: 'single'
 description_short: "Easily integrate MultiSafepay payment solutions into your CS-Cart webshop with the free plugin."
 description: "Easily integrate MultiSafepay payment solutions into your CS-Cart webshop with the free plugin."
-aliases: [/integrations/cs-cart/]
+aliases: 
+    - /plugins/cs-cart
+    - /integrations/plugins/cs-cart
+    - /integrations/cs-cart
 ---

--- a/content/integrations/ecommerce integrations/cs-cart/manual.md
+++ b/content/integrations/ecommerce integrations/cs-cart/manual.md
@@ -2,7 +2,10 @@
 title : "MultiSafepay CS-Cart installation & configuration manual"
 meta_title: "CS-Cart plugin manual - MultiSafepay Docs"
 meta_description: "The MultiSafepay Documentation Center presents all relevant information about our Plugins and API. You can also find support pages for payment methods, tools and general questions as well as the contact details of our Support and Integration Teams."
-aliases: [/integrations/cs-cart/manual/]
+aliases:
+    - /plugins/cs-cart/manual
+    - /integrations/plugins/cs-cart/manual
+    - /integrations/cs-cart/manual
 ---
 
 ### Introduction

--- a/content/integrations/ecommerce integrations/drupal7/_index.md
+++ b/content/integrations/ecommerce integrations/drupal7/_index.md
@@ -13,5 +13,8 @@ title_short: "Drupal 7"
 description_short: "Easily integrate MultiSafepay payment solutions into your Drupal 7 webshop with the free plugin."
 description: "Easily integrate MultiSafepay payment solutions into your Drupal 7 webshop with the free plugin."
 layout: 'single'
-aliases: [/integrations/drupal7/]
+aliases: 
+    - /plugins/drupal7
+    - /integrations/plugins/drupal7
+    - /integrations/drupal7
 ---

--- a/content/integrations/ecommerce integrations/drupal7/manual.md
+++ b/content/integrations/ecommerce integrations/drupal7/manual.md
@@ -2,7 +2,10 @@
 title : "MultiSafepay Drupal 7 installation & configuration manual"
 meta_title: "Drupal 7 plugin manual - MultiSafepay Docs"
 meta_description: "The MultiSafepay Documentation Center presents all relevant information about our Plugins and API. You can also find support pages for payment methods, tools and general questions as well as the contact details of our Support and Integration Teams."
-aliases: [/integrations/drupal7/manual/]
+aliases: 
+    - /plugins/drupal7/manual
+    - /integrations/plugins/drupal7/manual
+    - /integrations/drupal7/manual
 ---
 
 ## Introduction

--- a/content/integrations/ecommerce integrations/drupal8/_index.md
+++ b/content/integrations/ecommerce integrations/drupal8/_index.md
@@ -13,5 +13,8 @@ weight: 100
 title_short: "Drupal 8 & 9"
 description_short: "Easily integrate MultiSafepay payment solutions into your Drupal 8 webshop with the free plugin."
 description: "Easily integrate MultiSafepay payment solutions into your Drupal 8 webshop with the free plugin."
-aliases: [/integrations/drupal8/]
+aliases: 
+    - /plugins/drupal8
+    - /integrations/plugins/drupal8
+    - /integrations/drupal8
 ---

--- a/content/integrations/ecommerce integrations/drupal8/manual.md
+++ b/content/integrations/ecommerce integrations/drupal8/manual.md
@@ -2,7 +2,10 @@
 title : "MultiSafepay Drupal 8 & 9 installation & configuration manual"
 meta_title: "Drupal 8 & 9 plugin manual - MultiSafepay Docs"
 meta_description: "The MultiSafepay Documentation Center presents all relevant information about our Plugins and API. You can also find support pages for payment methods, tools and general questions as well as the contact details of our Support and Integration Teams."
-aliases: [/integrations/drupal8/manual/]
+aliases: 
+    - /plugins/drupal8/manual
+    - /integrations/plugins/drupal8/manual
+    - /integrations/drupal8/manual
 ---
 
 ### Introduction  

--- a/content/integrations/ecommerce integrations/dynamicweb/_index.md
+++ b/content/integrations/ecommerce integrations/dynamicweb/_index.md
@@ -11,4 +11,8 @@ description: "Easily integrate MultiSafepay payment solutions into your Dynamicw
 This app is managed by our partner Dynamicweb. For support, please contact [Dynamicweb](https://www.dynamicweb.com/about/contact-us) directly. 
 If you would like to integrate the MultiSafepay plugin for Dynamicweb, please contact our Integration Team at <integration@multisafepay.com>"
 layout: 'single'
+aliases: 
+    - /hosted/dynamicweb
+    - /integrations/hosted/dynamicweb
+    - /integrations/dynamicweb
 ---

--- a/content/integrations/ecommerce integrations/easywebshop/_index.md
+++ b/content/integrations/ecommerce integrations/easywebshop/_index.md
@@ -11,4 +11,8 @@ description: "Easily integrate MultiSafepay payment solutions into your EasyWebs
 This app is managed by our partner EasyWebshop. For support, please contact [EasyWebshop](https://www.easywebshop.com/software/contact) directly. 
 If you would like to integrate the MultiSafepay plugin for EasyWebshop, please contact our Integration Team at <integration@multisafepay.com>"
 layout: 'single'
+aliases: 
+    - /hosted/easywebshop
+    - /integrations/hosted/easywebshop
+    - /integrations/easywebshop
 ---

--- a/content/integrations/ecommerce integrations/ecwid/_index.md
+++ b/content/integrations/ecommerce integrations/ecwid/_index.md
@@ -11,5 +11,8 @@ description_short: "Easily integrate MultiSafepay payment solutions into your Ec
 description: "Easily integrate MultiSafepay payment solutions into your Ecwid store.
 This app is managed by Ecwid, for support please contact [Ecwid](https://support.ecwid.com/hc/en-us/requests/new)"
 layout: 'single'
-aliases: [/integrations/ecwid/]
+aliases: 
+    - /hosted/ecwid
+    - /integrations/hosted/ecwid
+    - /integrations/ecwid
 ---

--- a/content/integrations/ecommerce integrations/ecwid/manual.md
+++ b/content/integrations/ecommerce integrations/ecwid/manual.md
@@ -5,6 +5,8 @@ meta_description: "The MultiSafepay Documentation Center presents all relevant i
 aliases: 
   - /integrations/ecwid/manual/
   - /faq/general/can-i-use-multisafepay-with-wix/
+  - /hosted/ecwid/manual
+  - /integrations/hosted/ecwid/manual
 ---
 
 ### Introduction

--- a/content/integrations/ecommerce integrations/lightspeed_app/_index.md
+++ b/content/integrations/ecommerce integrations/lightspeed_app/_index.md
@@ -15,4 +15,7 @@ description: "Easily integrate MultiSafepay payment solutions into your Lightspe
 aliases: 
     - /integrations/hosted/lightspeed/
     - /integrations/hosted/lightspeedbeta/
+    - /hosted/lightspeed_app
+    - /integrations/hosted/lightspeed_app
+    - /integrations/lightspeed_app
 ---

--- a/content/integrations/ecommerce integrations/lightspeed_app/manual.md
+++ b/content/integrations/ecommerce integrations/lightspeed_app/manual.md
@@ -2,8 +2,12 @@
 title : "MultiSafepay Lightspeed installation & configuration manual"
 meta_title: "Lightspeed app  manual - MultiSafepay Docs"
 meta_description: "The MultiSafepay Documentation Center presents all relevant information about our Plugins and API. You can also find support pages for payment methods, tools and general questions as well as the contact details of our Support and Integration Teams."
-aliases:
-    - /support-tab/lighstpeed/manual
+aliases: 
+    - /integrations/hosted/lightspeed/manual
+    - /integrations/hosted/lightspeedbeta/manual
+    - /hosted/lightspeed_app/manual
+    - /integrations/hosted/lightspeed_app/manual
+    - /integrations/lightspeed_app/manual
 ---
 
 ### Introduction

--- a/content/integrations/ecommerce integrations/lightspeed_core/_index.md
+++ b/content/integrations/ecommerce integrations/lightspeed_core/_index.md
@@ -13,5 +13,8 @@ description: "Easily integrate MultiSafepay payment solutions into your Lightspe
 This core integration is managed by our partner Lightspeed. For support, please contact [Lightspeed](https://www.lightspeedhq.nl/support) directly."
 layout: 'single'
 tags: 'hidden'
-aliases: [/integrations/lightspeed/]
+aliases: 
+    - /hosted/lightspeed_core
+    - /integrations/hosted/lightspeed_core
+    - /integrations/lightspeed_core
 ---

--- a/content/integrations/ecommerce integrations/lightspeed_core/manual.md
+++ b/content/integrations/ecommerce integrations/lightspeed_core/manual.md
@@ -2,7 +2,11 @@
 title : "MultiSafepay Lightspeed installation & configuration manual"
 meta_title: "Lightspeed plugin manual - MultiSafepay Docs"
 meta_description: "The MultiSafepay Documentation Center presents all relevant information about our Plugins and API. You can also find support pages for payment methods, tools and general questions as well as the contact details of our Support and Integration Teams."
-aliases: [/integrations/lightspeed/manual/]
+aliases: 
+    - /hosted/lightspeed_core/manual
+    - /integrations/hosted/lightspeed_core/manual
+    - /integrations/lightspeed_core/manual
+    - /integrations/lightspeed/manual
 ---
 
 ### Introduction

--- a/content/integrations/ecommerce integrations/logic4/_index.md
+++ b/content/integrations/ecommerce integrations/logic4/_index.md
@@ -10,5 +10,9 @@ title_short: "Logic4"
 description_short: "Easily integrate MultiSafepay payment solutions into your Logic4 webshop."
 description: "This plugin is managed by our partner. For support please contact [Logic4](https://www.logic4.nl/contact) directly."
 layout: 'single'
-aliases: [/integrations/logic4/]
+aliases: 
+    - /integrations/logic4/
+    - /hosted/logic4
+    - /integrations/hosted/logic4
+    - /integrations/logic4
 ---

--- a/content/integrations/ecommerce integrations/logic4/manual.md
+++ b/content/integrations/ecommerce integrations/logic4/manual.md
@@ -2,8 +2,13 @@
 title : "MultiSafepay Logic4 installation & configuration manual"
 meta_title: "Logic4 plugin manual - MultiSafepay Docs"
 meta_description: "The MultiSafepay Documentation Center presents all relevant information about our Plugins and API. You can also find support pages for payment methods, tools and general questions as well as the contact details of our Support and Integration Teams."
-aliases: [/integrations/logic4/manual/]
+aliases: 
+    - /integrations/logic4/manual
+    - /hosted/logic4/manual
+    - /integrations/hosted/logic4/manual
+    - /integrations/logic4/manual
 ---
+
 ### Introduction
 
 {{% introduction_hosted "Logic4" %}}

--- a/content/integrations/ecommerce integrations/logivert/_index.md
+++ b/content/integrations/ecommerce integrations/logivert/_index.md
@@ -10,7 +10,10 @@ title_short: "LogiVert"
 description_short: "Easily integrate MultiSafepay payment solutions into your LogiVert app."
 description: "Easily integrate MultiSafepay payment solutions into your LogiVert app. This app is managed by LogiVert. For support please contact [LogiVert](https://www.logivert.com/nl/ons-bedrijf/c-2) directly."
 layout: 'single'
-aliases: [/integrations/logivert/]
+aliases: 
+    - /hosted/logivert
+    - /integrations/hosted/logivert
+    - /integrations/logivert
 ---
 
 Easily integrate MultiSafepay payment solutions into your LogiVert app. This app is managed by LogiVert. For support please contact [LogiVert](https://www.logivert.com/nl/ons-bedrijf/c-2) directly.

--- a/content/integrations/ecommerce integrations/logivert/manual.md
+++ b/content/integrations/ecommerce integrations/logivert/manual.md
@@ -2,7 +2,10 @@
 title : "MultiSafepay LogiVert installation & configuration manual"
 meta_title: "LogiVert plugin manual - MultiSafepay Docs"
 meta_description: "The MultiSafepay Documentation Center presents all relevant information about our Plugins and API. You can also find support pages for payment methods, tools and general questions as well as the contact details of our Support and Integration Teams."
-aliases: [/integrations/logivert/manual/]
+aliases: 
+    - /hosted/logivert/manual
+    - /integrations/hosted/logivert/manual
+    - /integrations/logivert/manual
 ---
 ### Introduction
 

--- a/content/integrations/ecommerce integrations/magento1/_index.md
+++ b/content/integrations/ecommerce integrations/magento1/_index.md
@@ -14,5 +14,8 @@ weight: 30
 title_short: "Magento 1"
 description_short: "Easily integrate MultiSafepay payment solutions into your Magento 1 webshop with the free and completely new MultiSafepay Magento 1 plugin."
 layout: 'single'
-aliases: [/integrations/magento1/]
+aliases: 
+    - /plugins/magento1
+    - /integrations/plugins/magento1
+    - /integrations/magento1
 ---

--- a/content/integrations/ecommerce integrations/magento1/manual.md
+++ b/content/integrations/ecommerce integrations/magento1/manual.md
@@ -2,7 +2,10 @@
 title : "MultiSafepay Magento 1 installation & configuration manual"
 meta_title: "Magento 1 plugin manual - MultiSafepay Docs"
 meta_description: "The MultiSafepay Documentation Center presents all relevant information about our Plugins and API. You can also find support pages for payment methods, tools and general questions as well as the contact details of our Support and Integration Teams."
-aliases: [/integrations/magento1/manual/]
+aliases: 
+    - /plugins/magento1/manual
+    - /integrations/plugins/magento1/manual
+    - /integrations/magento1/manual
 ---
 
 {{< alert-notice >}} Magento 1 is end-of-life. If you are still running Magento 1, action is required. MultiSafepay has partnered with Mage One to continue supporting Magento 1 in the future. Please read our [blog](https://bit.ly/2YX2LGL) for more information and the actions to take.{{< /alert-notice >}}

--- a/content/integrations/ecommerce integrations/magento2/_index.md
+++ b/content/integrations/ecommerce integrations/magento2/_index.md
@@ -18,5 +18,8 @@ weight: 01
 logo: "/logo/Plugins/Magento_2.svg"
 title_short: "Magento 2"
 description_short: "The MultiSafepay Magento 2 plugin. Easily integrate MultiSafepay payment solutions into your Magento 2 webshop with the free plugin."
-aliases: [/integrations/magento2/]
+aliases: 
+    - /plugins/magento2
+    - /integrations/plugins/magento2
+    - /integrations/magento2
 ---

--- a/content/integrations/ecommerce integrations/magento2/manual.md
+++ b/content/integrations/ecommerce integrations/magento2/manual.md
@@ -5,7 +5,9 @@ layout: 'single'
 meta_description: "The MultiSafepay Documentation Center presents all relevant information about our Plugins and API. You can also find support pages for payment methods, tools and general questions as well as the contact details of our Support and Integration Teams."
 aliases:
     - /support-tab/magento2/manual
-    - /integrations/magento2/manual/
+    - /plugins/magento2/manual
+    - /integrations/plugins/magento2/manual
+    - /integrations/magento2/manual
 ---
 
 ### Introduction

--- a/content/integrations/ecommerce integrations/mijnwebwinkel/_index.md
+++ b/content/integrations/ecommerce integrations/mijnwebwinkel/_index.md
@@ -11,4 +11,8 @@ description_short: "Easily integrate MultiSafepay payment solutions into your Mi
 description: "Easily integrate MultiSafepay payment solutions into your Mijnwebwinkel with this free app. This app is managed by our partner Mijnwebwinkel (MyOnlineStore). For support please contact [Mijnwebwinkel](https://www.mijnwebwinkel.nl/support) directly."
 layout: 'single'
 aliases: [/integrations/mijnwebwinkel/]
+aliases: 
+    - /hosted/mijnwebwinkel
+    - /integrations/hosted/mijnwebwinkel
+    - /integrations/mijnwebwinkel
 ---

--- a/content/integrations/ecommerce integrations/mijnwebwinkel/manual.md
+++ b/content/integrations/ecommerce integrations/mijnwebwinkel/manual.md
@@ -2,7 +2,10 @@
 title : "MultiSafepay Mijnwebwinkel installation & configuration manual"
 meta_title: "Mijnwebwinkel plugin manual - MultiSafepay Docs"
 meta_description: "The MultiSafepay Documentation Center presents all relevant information about our Plugins and API. You can also find support pages for payment methods, tools and general questions as well as the contact details of our Support and Integration Teams."
-aliases: [/integrations/mijnwebwinkel/manual/]
+aliases: 
+    - /hosted/mijnwebwinkel/manual
+    - /integrations/hosted/mijnwebwinkel/manual
+    - /integrations/mijnwebwinkel/manual
 ---
 ### Introduction
 

--- a/content/integrations/ecommerce integrations/myshop/_index.md
+++ b/content/integrations/ecommerce integrations/myshop/_index.md
@@ -11,5 +11,8 @@ description_short: "Easily integrate MultiSafepay payment solutions into your my
 description: "Easily integrate MultiSafepay payment solutions into your myShop with this free app.
 This app is managed by our partner myShop. For support please contact [myShop](https://www.myshop.com/contact) directly."
 layout: 'single'
-aliases: [/integrations/myshop/]
+aliases: 
+    - /hosted/myshop
+    - /integrations/hosted/myshop
+    - /integrations/logivert
 ---

--- a/content/integrations/ecommerce integrations/myshop/manual.md
+++ b/content/integrations/ecommerce integrations/myshop/manual.md
@@ -2,7 +2,10 @@
 title : "MultiSafepay myShop installation & configuration manual"
 meta_title: "myShop plugin manual - MultiSafepay Docs"
 meta_description: "The MultiSafepay Documentation Center presents all relevant information about our Plugins and API. You can also find support pages for payment methods, tools and general questions as well as the contact details of our Support and Integration Teams."
-aliases: [/integrations/myshop/manual/]
+aliases: 
+    - /hosted/myshop/manual
+    - /integrations/hosted/myshop/manual
+    - /integrations/myshop:w/manual
 ---
 ### Introduction
 

--- a/content/integrations/ecommerce integrations/odoo/_index.md
+++ b/content/integrations/ecommerce integrations/odoo/_index.md
@@ -14,4 +14,8 @@ weight: 80
 logo: "/logo/Plugins/Odoo.svg"
 title_short: "Odoo"
 description_short: "The MultiSafepay Odoo plugin. Easily integrate MultiSafepay payment solutions into your Odoo webshop with the free plugin."
+aliases: 
+    - /plugins/odoo
+    - /integrations/plugins/odoo
+    - /integrations/odoo
 ---

--- a/content/integrations/ecommerce integrations/odoo/manual.md
+++ b/content/integrations/ecommerce integrations/odoo/manual.md
@@ -4,6 +4,9 @@ meta_title: "Odoo plugin manual - MultiSafepay Docs"
 meta_description: "The MultiSafepay Documentation Center presents all relevant information about our Plugins and API. You can also find support pages for payment methods, tools and general questions as well as the contact details of our Support and Integration Teams."
 aliases:
     - /support-tab/odoo/manual
+    - /plugins/odoo/manual
+    - /integrations/plugins/odoo/manual
+    - /integrations/odoo/manual
 ---
 
 ### 1. Requirements

--- a/content/integrations/ecommerce integrations/opencart/_index.md
+++ b/content/integrations/ecommerce integrations/opencart/_index.md
@@ -13,7 +13,10 @@ description_short: "Have an OpenCart webshop? Integrate the MultiSafepay payment
 description: "The free plugin to easily integrate MultiSafepay payment solutions into your OpenCart webshop."
 layout: 'single'
 changelog : "https://github.com/MultiSafepay/Opencart/blob/master/CHANGELOG.md"
-aliases: [/integrations/opencart/]
+aliases: 
+    - /plugins/opencart
+    - /integrations/plugins/opencart
+    - /integrations/opencart
 ---
 
 

--- a/content/integrations/ecommerce integrations/opencart/manual.md
+++ b/content/integrations/ecommerce integrations/opencart/manual.md
@@ -2,7 +2,11 @@
 title : "MultiSafepay OpenCart installation & configuration manual"
 meta_title: "OpenCart plugin manual - MultiSafepay Docs"
 meta_description: "The MultiSafepay Documentation Center presents all relevant information about our Plugins and API. You can also find support pages for payment methods, tools and general questions as well as the contact details of our Support and Integration Teams."
-aliases: [/integrations/opencart/manual/]
+aliases:
+    - /support-tab/opencart/manual
+    - /plugins/opencart/manual
+    - /integrations/plugins/opencart/manual
+    - /integrations/opencart/manual
 ---
 
 ### Introduction

--- a/content/integrations/ecommerce integrations/oscommerce/_index.md
+++ b/content/integrations/ecommerce integrations/oscommerce/_index.md
@@ -16,7 +16,10 @@ Plugin version 3.0.0 available at MultiSafepay is tested on PHP 5.6. Do mind tha
 
 Contact your account manager for further information at <sales@multisafepay.com>"
 layout: 'single'
-aliases: [/integrations/oscommerce/]
+aliases: 
+    - /plugins/oscommerce
+    - /integrations/plugins/oscommerce
+    - /integrations/oscommerce
 ---
 
 

--- a/content/integrations/ecommerce integrations/oscommerce/manual.md
+++ b/content/integrations/ecommerce integrations/oscommerce/manual.md
@@ -2,7 +2,10 @@
 title : "MultiSafepay OsCommerce installation & configuration manual"
 meta_title: "OsCommerce plugin manual - MultiSafepay Docs"
 meta_description: "The MultiSafepay Documentation Center presents all relevant information about our Plugins and API. You can also find support pages for payment methods, tools and general questions as well as the contact details of our Support and Integration Teams."
-aliases: [/integrations/oscommerce/manual/]
+aliases:
+    - /plugins/oscommerce/manual
+    - /integrations/plugins/oscommerce/manual
+    - /integrations/oscommerce/manual
 ---
 
 ### Introduction

--- a/content/integrations/ecommerce integrations/prestashop-1-6/_index.md
+++ b/content/integrations/ecommerce integrations/prestashop-1-6/_index.md
@@ -14,5 +14,9 @@ title_short: "PrestaShop 1.6"
 description_short: "Easily integrate MultiSafepay payment solutions into your Prestashop 1.6 webshop with the free plugin. "
 description: "Easily integrate MultiSafepay payment solutions into your Prestashop 1.6 webshop with the free plugin. "
 layout: 'single'
-aliases: [/integrations/prestashop-1-6/]
+aliases: 
+    - /plugins/prestashop-1-6
+    - /integrations/plugins/prestashop-1-6
+    - /integrations/prestashop-1-6
+
 ---

--- a/content/integrations/ecommerce integrations/prestashop-1-6/manual.md
+++ b/content/integrations/ecommerce integrations/prestashop-1-6/manual.md
@@ -3,7 +3,10 @@ title : "MultiSafepay PrestaShop 1.6 installation & configuration manual"
 weight:
 meta_title: "PrestaShop 1.6 plugin manual - MultiSafepay Docs"
 meta_description: "The MultiSafepay Documentation Center presents all relevant information about our Plugins and API. You can also find support pages for payment methods, tools and general questions as well as the contact details of our Support and Integration Teams."
-aliases: [/integrations/prestashop-1-6/manual/]
+aliases:
+    - /plugins/prestashop-1-6/manual
+    - /integrations/plugins/prestashop-1-6/manual
+    - /integrations/prestashop-1-6/manual
 ---
 
 ### Introduction

--- a/content/integrations/ecommerce integrations/prestashop-1-7/_index.md
+++ b/content/integrations/ecommerce integrations/prestashop-1-7/_index.md
@@ -16,7 +16,10 @@ description_short: "The free plugin for MultiSafepay payment solutions to use wi
 description: "Easily integrate MultiSafepay payment solutions into your Prestashop 1.7 webshop with the free plugin."
 layout: 'single'
 changelog: 'https://github.com/MultiSafepay/PrestaShop/blob/master/CHANGELOG.md'
-aliases: [/integrations/prestashop-1-7/]
+aliases: 
+    - /plugins/prestashop-1-7
+    - /integrations/plugins/prestashop-1-7
+    - /integrations/prestashop-1-7
 ---
 
 

--- a/content/integrations/ecommerce integrations/prestashop-1-7/manual.md
+++ b/content/integrations/ecommerce integrations/prestashop-1-7/manual.md
@@ -3,7 +3,10 @@ title : "MultiSafepay PrestaShop 1.7 installation & configuration manual"
 weight:
 meta_title: "PrestaShop 1.7 plugin manual - MultiSafepay Docs"
 meta_description: "The MultiSafepay Documentation Center presents all relevant information about our Plugins and API. You can also find support pages for payment methods, tools and general questions as well as the contact details of our Support and Integration Teams."
-aliases: [/integrations/prestashop-1-7/manual/]
+aliases:
+    - /plugins/prestashop-1-7/manual
+    - /integrations/plugins/prestashop-1-7/manual
+    - /integrations/prestashop-1-7/manual
 ---
 
 ### Introduction

--- a/content/integrations/ecommerce integrations/sanacommerce/_index.md
+++ b/content/integrations/ecommerce integrations/sanacommerce/_index.md
@@ -10,4 +10,9 @@ description_short: "Easily integrate MultiSafepay payment solutions into your Sa
 description: "Easily integrate MultiSafepay payment solutions into your Sana Commerce platform with the free app. Please note that the minimum version of Sana Commerce required to use MultiSafepay is version 9.3. If you would like to integrate MultiSafepay with Sana Commerce, please visit the main website of [Sana Commerce for step-by-step instructions](https://help.sana-commerce.com/sana-commerce-93/payment-services/multisafepay/introduction)  
 This app is managed by our partner Sana Commerce. For support, please contact [Sana Commerce](https://www.sana-commerce.com/nl/contact) directly."
 layout: 'single'
+aliases: 
+    - /integrations/sanacommerce/
+    - /hosted/sanacommerce
+    - /integrations/hosted/sanacommerce
+    - /integrations/sanacommerce
 ---

--- a/content/integrations/ecommerce integrations/shopfactory/_index.md
+++ b/content/integrations/ecommerce integrations/shopfactory/_index.md
@@ -13,5 +13,9 @@ description: "Easily integrate MultiSafepay payment solutions into your ShopFact
 
 This plugin is managed by our partner ShopFactory. For support please contact [ShopFactory](https://www.shopfactory.nl/contents/nl/d122.html) directly."
 layout: 'single'
-aliases: [/integrations/shopfactory/]
+aliases: 
+    - /integrations/shopfactory/
+    - /hosted/shopfactory
+    - /integrations/hosted/shopfactory
+    - /integrations/shopfactory
 ---

--- a/content/integrations/ecommerce integrations/shopfactory/manual.md
+++ b/content/integrations/ecommerce integrations/shopfactory/manual.md
@@ -2,7 +2,11 @@
 title : "MultiSafepay ShopFactory installation & configuration manual"
 meta_title: "ShopFactory plugin manual - MultiSafepay Docs"
 meta_description: "The MultiSafepay Documentation Center presents all relevant information about our Plugins and API. You can also find support pages for payment methods, tools and general questions as well as the contact details of our Support and Integration Teams."
-aliases: [/integrations/shopfactory/manual/]
+aliases: 
+    - /integrations/shopfactory/manual
+    - /hosted/shopfactory/manual
+    - /integrations/hosted/shopfactory/manual
+    - /integrations/shopfactory/manual
 ---
 ### Introduction
 

--- a/content/integrations/ecommerce integrations/shopify/_index.md
+++ b/content/integrations/ecommerce integrations/shopify/_index.md
@@ -11,5 +11,8 @@ title_short: "Shopify"
 description_short: "Easily integrate MultiSafepay payment solutions into your Shopify webshop with the free app."
 description: "Easily integrate MultiSafepay payment solutions into your Shopify webshop with the free app."
 layout: 'single'
-aliases: [/integrations/shopify/]
+aliases: 
+    - /hosted/shopify
+    - /integrations/hosted/shopify
+    - /integrations/shopify
 ---

--- a/content/integrations/ecommerce integrations/shopify/manual.md
+++ b/content/integrations/ecommerce integrations/shopify/manual.md
@@ -3,8 +3,11 @@ title : "MultiSafepay Shopify installation & configuration manual"
 meta_title: "Shopify plugin manual - MultiSafepay Docs"
 meta_description: "The MultiSafepay Documentation Center presents all relevant information about our Plugins and API. You can also find support pages for payment methods, tools and general questions as well as the contact details of our Support and Integration Teams."
 aliases: 
-  - /integrations/shopify/manual/
-  - /integrations/shopify/faq/how-can-i-update-the-plugin-for-shopify/
+    - /integrations/shopify/faq/how-can-i-update-the-plugin-for-shopify/
+    - /integrations/shopify/manual
+    - /hosted/shopify/manual
+    - /integrations/hosted/shopify/manual
+    - /integrations/shopify/manual
 ---
 
 ### Introduction

--- a/content/integrations/ecommerce integrations/shoptrader/_index.md
+++ b/content/integrations/ecommerce integrations/shoptrader/_index.md
@@ -11,5 +11,9 @@ description_short: "Easily integrate MultiSafepay payment solutions into your Sh
 description: "Easily integrate MultiSafepay payment solutions into your Shoptrader webshop with the free plugin. 
 This plugin is managed by our partner Shoptrader. For support please contact [Shoptrader](https://support.shoptrader.nl) directly."
 layout: 'single'
-aliases: [/integrations/shoptrader/]
+aliases: 
+    - /integrations/shoptrader/
+    - /hosted/shoptrader
+    - /integrations/hosted/shoptrader
+    - /integrations/shoptrader]
 ---

--- a/content/integrations/ecommerce integrations/shoptrader/manual.md
+++ b/content/integrations/ecommerce integrations/shoptrader/manual.md
@@ -2,7 +2,11 @@
 title : "MultiSafepay Shoptrader installation & configuration manual"
 meta_title: "Shoptrader plugin manual - MultiSafepay Docs"
 meta_description: "The MultiSafepay Documentation Center presents all relevant information about our Plugins and API. You can also find support pages for payment methods, tools and general questions as well as the contact details of our Support and Integration Teams."
-aliases: [/integrations/shoptrader/manual/]
+aliases: 
+    - /integrations/shoptrader/manual
+    - /hosted/shoptrader/manual
+    - /integrations/hosted/shoptrader/manual
+    - /integrations/shoptrader/manual
 ---
 ### Introduction
 

--- a/content/integrations/ecommerce integrations/shopware5/_index.md
+++ b/content/integrations/ecommerce integrations/shopware5/_index.md
@@ -14,6 +14,9 @@ description_short: "Easily integrate MultiSafepay payment solutions into your Sh
 description: "Easily integrate MultiSafepay payment solutions into your Shopware 5 webshop with the free plugin."
 layout: 'single'
 changelog : "https://github.com/MultiSafepay/Shopware/blob/master/CHANGELOG.md"
-aliases: [/integrations/shopware5/]
+aliases: 
+    - /plugins/shopware5
+    - /integrations/plugins/shopware5
+    - /integrations/shopware5
 ---
 

--- a/content/integrations/ecommerce integrations/shopware5/manual.md
+++ b/content/integrations/ecommerce integrations/shopware5/manual.md
@@ -2,7 +2,10 @@
 title : "MultiSafepay Shopware 5 installation & configuration manual"
 meta_title: "Shopware 5 plugin manual - MultiSafepay Docs"
 meta_description: "The MultiSafepay Documentation Center presents all relevant information about our Plugins and API. You can also find support pages for payment methods, tools and general questions as well as the contact details of our Support and Integration Teams."
-aliases: [/integrations/shopware5/manual/]
+aliases:
+    - /plugins/shopware5/manual
+    - /integrations/plugins/shopware5/manual
+    - /integrations/shopware5/manual
 ---
 
 ### Introduction

--- a/content/integrations/ecommerce integrations/shopware6/_index.md
+++ b/content/integrations/ecommerce integrations/shopware6/_index.md
@@ -14,6 +14,9 @@ description_short: "Easily integrate MultiSafepay payment solutions into your Sh
 description: "Easily integrate MultiSafepay payment solutions into your Shopware 6 webshop with the free plugin."
 layout: 'single'
 changelog : "https://github.com/MultiSafepay/shopware6/blob/master/CHANGELOG.md"
-aliases: [/integrations/shopware6/]
+aliases: 
+    - /plugins/shopware6
+    - /integrations/plugins/shopware6
+    - /integrations/shopware6
 ---
 

--- a/content/integrations/ecommerce integrations/shopware6/manual.md
+++ b/content/integrations/ecommerce integrations/shopware6/manual.md
@@ -2,7 +2,10 @@
 title : "MultiSafepay Shopware 6 installation & configuration manual"
 meta_title: "Shopware 6 plugin manual - MultiSafepay Docs"
 meta_description: "The MultiSafepay Documentation Center presents all relevant information about our Plugins and API. You can also find support pages for payment methods, tools and general questions as well as the contact details of our Support and Integration Teams."
-aliases: [/integrations/shopware6/manual/]
+aliases:
+    - /plugins/shopware6/manual
+    - /integrations/plugins/shopware6/manual
+    - /integrations/shopware6/manual
 ---
 
 ### Introduction

--- a/content/integrations/ecommerce integrations/virtuemart/_index.md
+++ b/content/integrations/ecommerce integrations/virtuemart/_index.md
@@ -15,4 +15,8 @@ description: "Easily integrate MultiSafepay payment solutions into your VirtueMa
 layout: 'single'
 changelog : "https://github.com/MultiSafepay/VirtueMart/blob/master/CHANGELOG.md"
 aliases: [/integrations/virtuemart/]
+aliases:
+    - /plugins/virtuemart
+    - /integrations/plugins/virtuemart
+    - /integrations/virtuemart
 ---

--- a/content/integrations/ecommerce integrations/virtuemart/manual.md
+++ b/content/integrations/ecommerce integrations/virtuemart/manual.md
@@ -2,7 +2,11 @@
 title : "MultiSafepay VirtueMart installation & configuration manual"
 meta_title: "VirtueMart plugin manual - MultiSafepay Docs"
 meta_description: "The MultiSafepay Documentation Center presents all relevant information about our Plugins and API. You can also find support pages for payment methods, tools and general questions as well as the contact details of our Support and Integration Teams."
-aliases: [/integrations/virtuemart/manual/]
+aliases:
+    - /plugins/virtuemart/manual
+    - /integrations/plugins/virtuemart/manual
+    - /integrations/virtuemart/manual
+
 ---
 
 ### Introduction

--- a/content/integrations/ecommerce integrations/woocommerce/_index.md
+++ b/content/integrations/ecommerce integrations/woocommerce/_index.md
@@ -16,6 +16,9 @@ description_short: "Integrate MultiSafepay payment solutions into your WooCommer
 description: "Easily integrate MultiSafepay payment solutions into your WooCommerce webshop with our free plugin."
 layout: 'single'
 changelog : "https://github.com/MultiSafepay/WooCommerce/blob/master/CHANGELOG.md"
-aliases: [/integrations/woocommerce/]
+aliases: 
+    - /plugins/woocommerce
+    - /integrations/plugins/woocommerce
+    - /integrations/woocommerce
 ---
 

--- a/content/integrations/ecommerce integrations/woocommerce/manual.md
+++ b/content/integrations/ecommerce integrations/woocommerce/manual.md
@@ -2,7 +2,10 @@
 title : "MultiSafepay WooCommerce installation & configuration manual"
 meta_title: "WooCommerce plugin manual - MultiSafepay Docs"
 meta_description: "The MultiSafepay Documentation Center presents all relevant information about our Plugins and API. You can also find support pages for payment methods, tools and general questions as well as the contact details of our Support and Integration Teams."
-aliases: [/integrations/woocommerce/manual/]
+aliases:
+    - /plugins/woocommerce/manual
+    - /integrations/plugins/woocommerce/manual
+    - /integrations/woocommerce/manual
 ---
 
 ### Introduction

--- a/content/integrations/ecommerce integrations/x-cart/_index.md
+++ b/content/integrations/ecommerce integrations/x-cart/_index.md
@@ -15,4 +15,8 @@ description: "Easily integrate MultiSafepay payment solutions into your X-Cart w
 layout: 'single'
 changelog : "https://github.com/MultiSafepay/X-Cart/blob/master/CHANGELOG.md"
 aliases: [/integrations/x-cart/]
+aliases:
+    - /plugins/x-cart
+    - /integrations/plugins/x-cart
+    - /integrations/x-cart
 ---

--- a/content/integrations/ecommerce integrations/x-cart/manual.md
+++ b/content/integrations/ecommerce integrations/x-cart/manual.md
@@ -3,6 +3,10 @@ title : "MultiSafepay X-Cart installation & configuration manual"
 meta_title: "X-Cart plugin manual - MultiSafepay Docs"
 meta_description: "The MultiSafepay Documentation Center presents all relevant information about our Plugins and API. You can also find support pages for payment methods, tools and general questions as well as the contact details of our Support and Integration Teams."
 aliases: [/integrations/x-cart/manual/]
+aliases:
+    - /plugins/x-cart/manual
+    - /integrations/plugins/x-cart/manual
+    - /integrations/x-cart/manual
 ---
 
 ### Introduction

--- a/content/integrations/ecommerce integrations/zencart/_index.md
+++ b/content/integrations/ecommerce integrations/zencart/_index.md
@@ -15,5 +15,9 @@ description: "Easily integrate MultiSafepay payment solutions into your Zen Cart
 layout: 'single'
 changelog : "https://github.com/MultiSafepay/Zencart/blob/master/CHANGELOG.md"
 aliases: [/integrations/zencart/]
+aliases: 
+    - /plugins/zencart
+    - /integrations/plugins/zencart
+    - /integrations/zencart
 ---
 

--- a/content/integrations/ecommerce integrations/zencart/manual.md
+++ b/content/integrations/ecommerce integrations/zencart/manual.md
@@ -2,7 +2,10 @@
 title : "MultiSafepay Zen Cart installation & configuration manual"
 meta_title: "ZenCart plugin manual - MultiSafepay Docs"
 meta_description: "The MultiSafepay Documentation Center presents all relevant information about our Plugins and API. You can also find support pages for payment methods, tools and general questions as well as the contact details of our Support and Integration Teams."
-aliases: [/integrations/zencart/manual/]
+aliases:
+    - /plugins/zencart/manual
+    - /integrations/plugins/zencart/manual
+    - /integrations/zencart/manual
 ---
 
 ### Introduction

--- a/content/integrations/ecommerce integrations/zilvercms/_index.md
+++ b/content/integrations/ecommerce integrations/zilvercms/_index.md
@@ -12,4 +12,8 @@ This app is managed by our partner ZilverCMS. For support, please contact [Zilve
 If you would like to integrate the MultiSafepay plugin for ZilverCMS, please contact our integration team at <integration@multisafepay.com>"
 layout: 'single'
 faq: "."
+aliases: 
+    - /hosted/zilvercms
+    - /integrations/hosted/zilvercms
+    - /integrations/zilvercms
 ---


### PR DESCRIPTION
### Basic
- We only accept documentation that is proved to work on our LIVE API
- At least 1 approval is needed before pull requests can be merged
- The article must match our Synonym word list. For external commits, a MultiSafepay employee will check
- US English must be applied
- Use bullets for numerations where the sort order doesn't matter. For chronological order, use numbers. This does not apply to changelogs
- Set link on email address.

### Text style
- Paths are written like: _Configuration → System → Plugin → MultiSafepay_
- Use single quotation marks in your Markdown code (example title: 'Title of the article')
- Use Italics for buttons, clicks, paths, etc. Do mind to close the italics before the end of a sentence followed by a period
- Numerations / bullets are punctuated with a period at the end of the numerations / bullets.
- Periods should be excluded for sentences that finish in an e-mail address (e.g. "..contact us at <example@example.com> "  )

### Images
- Screenshot recomended sizes: Width: 820px - Height: auto

### Aliases
- When renaming or deleting a page, add an alias of the renamed or deleted page to the page users should be redirected to instead. This prevents external links to return 404 errors. Check the [Hugo Documentation](https://gohugo.io/content-management/urls/#aliases) for more information.
