### PR TITLE
DOCS-2118: Add alias for OpenCart and WooCommerce FAQ index page

### DIFF
--- a/content/integrations/ecommerce integrations/opencart/faq/_index.md
+++ b/content/integrations/ecommerce integrations/opencart/faq/_index.md
@@ -3,5 +3,7 @@ title: 'FAQ'
 layout: 'faqplugins'
 meta_title: "OpenCart plugin FAQ - MultiSafepay Docs"
 meta_description: "The MultiSafepay Documentation Center presents all relevant information about our Plugins and API. You can also find support pages for payment methods, tools and general questions as well as the contact details of our Support and Integration Teams."
-aliases: [/integrations/opencart/faq/]
+aliases: 
+    - /integrations/opencart/faq
+    - /integrations/plugins/opencart/faq
 ---

--- a/content/integrations/ecommerce integrations/woocommerce/faq/_index.md
+++ b/content/integrations/ecommerce integrations/woocommerce/faq/_index.md
@@ -3,5 +3,7 @@ title: 'FAQ'
 layout: 'faqplugins'
 meta_title: "WooCommerce plugin FAQ - MultiSafepay Docs"
 meta_description: "The MultiSafepay Documentation Center presents all relevant information about our Plugins and API. You can also find support pages for payment methods, tools and general questions as well as the contact details of our Support and Integration Teams."
-aliases: [/integrations/woocommerce/faq/]
+aliases: 
+    - /integrations/woocommerce/faq
+    - /integrations/plugins/woocommerce/faq
 ---


### PR DESCRIPTION
### Basic
- We only accept documentation that is proved to work on our LIVE API
- At least 1 approval is needed before pull requests can be merged
- The article must match our Synonym word list. For external commits, a MultiSafepay employee will check
- US English must be applied
- Use bullets for numerations where the sort order doesn't matter. For chronological order, use numbers. This does not apply to changelogs
- Set link on email address.

### Text style
- Paths are written like: _Configuration → System → Plugin → MultiSafepay_
- Use single quotation marks in your Markdown code (example title: 'Title of the article')
- Use Italics for buttons, clicks, paths, etc. Do mind to close the italics before the end of a sentence followed by a period
- Numerations / bullets are punctuated with a period at the end of the numerations / bullets.
- Periods should be excluded for sentences that finish in an e-mail address (e.g. "..contact us at <example@example.com> "  )

### Images
- Screenshot recomended sizes: Width: 820px - Height: auto

### Aliases
- When renaming or deleting a page, add an alias of the renamed or deleted page to the page users should be redirected to instead. This prevents external links to return 404 errors. Check the [Hugo Documentation](https://gohugo.io/content-management/urls/#aliases) for more information.
