### PR TITLE
DOCS-2138: Add blue-notice shortcode for Magento 2 blogpost

### DIFF
--- a/content/integrations/ecommerce integrations/magento2/manual.md
+++ b/content/integrations/ecommerce integrations/magento2/manual.md
@@ -17,6 +17,11 @@ It brings code improvements, unit/integration testing and it is built on top of 
 
 **Please uninstall the old plugin first, before installing the new one.**
 
+{{< blue-notice >}}
+We have recently added support for Magento Instant Purchase and Magento Vault.  
+To learn more about these features, [read our blog](https://www.multisafepay.com/blog/magento-2-boost-conversion-through-magento-vault-instant-purchase)
+{{< /blue-notice >}}
+
 {{< alert-notice >}}
 The FAQ items regarding the old Magento 2 plugin have been moved to the [old plugin page](/integrations/ecommerce-integrations/magento2/old) 
 {{< /alert-notice >}}

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -36,7 +36,7 @@
     <link href="{{ .Site.BaseURL }}css/bootstrap.min.css" rel="stylesheet" />
     <link href="{{ .Site.BaseURL }}css/mburger.css" rel="stylesheet" />
     <link href="{{ .Site.BaseURL }}css/mmenu.css" rel="stylesheet" />
-    <link href="{{ .Site.BaseURL }}css/main.css?v=15" rel="stylesheet" />
+    <link href="{{ .Site.BaseURL }}css/main.css?v=16" rel="stylesheet" />
     <link rel="shortcut icon" href="/favicon.ico">
     <script src="{{ .Site.BaseURL }}js/mmenu.js"></script>
     <script src="{{ .Site.BaseURL }}js/main.js?v=8"></script>

--- a/layouts/shortcodes/blue-notice.html
+++ b/layouts/shortcodes/blue-notice.html
@@ -1,0 +1,5 @@
+<div class="blue-notice">
+    <span>
+        {{.Inner | markdownify}}
+    </span>
+</div>

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -1199,13 +1199,27 @@ p {
 
 .alert-notice {
     position: relative;
-    padding: .75rem 1.25rem;
+    padding: 1rem 1.25rem;
     margin-bottom: 1rem;
     border: 1px solid transparent;
-    border-radius: .25rem;
+    border-radius: 1rem;
     color: #856404;
     background-color: #fff3cd;
     border-color: #ffeeba;
+    font-size: 1.6rem;
+    font-weight: 300;
+    line-height: 1.5;
+}
+
+.blue-notice {
+    position: relative;
+    padding: 1rem 1.25rem;
+    margin-bottom: 1rem;
+    border: 1px solid transparent;
+    border-radius: 1rem;
+    color: #175C9B;
+    background-color: #DFEBF6;
+    border-color: #DFEBF6;
     font-size: 1.6rem;
     font-weight: 300;
     line-height: 1.5;
@@ -1517,7 +1531,7 @@ h6 {
 .copy-code-button {
     color: #272822;
     background-color: #F6F6F6;
-    border-radius: 10px 10px 0px 0px ;
+    border-radius: 1rem 1rem 0px 0px ;
     border: none;
 
     /* right-align */
@@ -1526,7 +1540,7 @@ h6 {
     margin-right: 0;
 
     margin-bottom: -2px;
-    padding: 3px 10px;
+    padding: 3px 12px;
     font-size: 0.9em;
 }
 
@@ -1556,7 +1570,7 @@ h6 {
 pre:not(.chroma) {
     background-color: #F6F6F6;
     color: #4D4D4D;
-    border-radius: 10px 0px 10px 10px;
+    border-radius: 1rem 0px 1rem 1rem;
     padding: 40px 50px;
 }
 


### PR DESCRIPTION
### Basic
- We only accept documentation that is proven to work on our LIVE API
- At least one approval is needed before pull requests can be merged
- All content is written in US English
- The terminology used must be in accordance with our naming conventions

### Text style
- Paths are formatted like: _Configuration → System → Plugin → MultiSafepay_
- Use single quotation marks in the front matter of markdown files (e.g., title: 'Title of the article')
- Use _italics_ when describing GUI elements (e.g., buttons, links and paths)
- When a sentence ends with an email address, don't use a period (e.g. "[...] contact us at <example@example.com>")

### Images
- Screenshot recommended sizes: Width: 820px - Height: auto

### Aliases
- When renaming or deleting a page, add an alias of the deprecated URL to the page users should be redirected to. This prevents external links from returning 404 errors. Check the [Hugo Documentation](https://gohugo.io/content-management/urls/#aliases) for more information.
