### PR TITLE
DOCS-2152: Remove notification URL for WooCommerce

### DIFF
--- a/content/tools/multisafepay-control/set-your-notification-url.md
+++ b/content/tools/multisafepay-control/set-your-notification-url.md
@@ -30,7 +30,7 @@ However, if the notification URL is not correctly set, the order will not update
 | Shopware 5  | Please contact the Integration Team at <integration@multisafepay.com>            |
 | Shopware 6     | Please contact the Integration Team at <integration@multisafepay.com>                 |
 | VirtueMart     | https://www.example.com/index.php?option=com_virtuemart&view=multisafepayresponse&mode=notify&type=initial&task=notify          |
-| WooCommerce    | https://www.example.com/?page=multisafepaynotify |
+| WooCommerce    | Please contact the Integration Team at <integration@multisafepay.com> |
 | X-Cart   | Please contact the Integration Team at <integration@multisafepay.com> |
 | Zen Cart    | https://www.example.com/ext/modules/payment/multisafepay/notify_checkout.php?type=initial |
 


### PR DESCRIPTION
Since WooCommerce plugin version 4.X.X the notification url in WooCommerce is dynamic and follow this format: 

[https://example.com/wc-api/multisafepay_{ID-OF-PAYMENT-METHOD}?transactionid={ORDER-NUMBER}&timestamp={TIME-STAMP}

Is hard to explain this in just a line, and that`s why I am changing the information to contact support team in case a merchant need it; in the same way other integrations do.  