### PR TITLE
DOCS-1998: Move shopping_cart notice for PAD in API reference

### DIFF
--- a/content/api/payment_methods/post-order-einvoicing.md
+++ b/content/api/payment_methods/post-order-einvoicing.md
@@ -263,8 +263,6 @@ Creates a E-invocing [Direct](/faq/api/difference-between-direct-and-redirect) o
 
 * All parameters shown are required field(s)
 
-{{< alert-notice >}} __Please note__: In order for the shopping_cart to work correctly, the shipment item requires a special 'merchant_item_id'. This parameter is called 'msp-shipping' and can be seen in the JSON code. {{< /alert-notice >}}
-
 **Parameters**
 
 ----------------
@@ -316,7 +314,9 @@ Contains the delivery information for the shipment. _Values for first_name and l
 
 __shopping_cart__ | object
 
-Contains all purchased items including tax class. If you are using your own integration, the transaction should be sent including the complete specification of the shopping_cart. 
+Contains all purchased items including tax class. If you are using your own integration, the transaction should be sent including the complete specification of the shopping_cart.
+
+ __Please note__: In order for the shopping_cart to function correctly, the shipment item requires a parameter ‘merchant_item_id’ with the value ‘msp-shipping'
 
 ----------------
 
@@ -379,9 +379,6 @@ Creates an E-invoicing [Redirect](/faq/api/difference-between-direct-and-redirec
 
 * All parameters shown are required field(s)
 
-{{< alert-notice >}} __Please note__: In order for the shopping_cart to work correctly, the shipment item requires a special 'merchant_item_id'. This parameter is called 'msp-shipping' and can be seen in the JSON code. {{< /alert-notice >}}
-
-
 **Parameters**
 
 ----------------
@@ -433,7 +430,9 @@ Contains the delivery information for the shipment. _Values for first_name and l
 
 __shopping_cart__ | object
 
-Contains all purchased items including tax class. If you are using your own integration, the transaction should be sent including the complete specification of the shopping_cart. 
+Contains all purchased items including tax class. If you are using your own integration, the transaction should be sent including the complete specification of the shopping_cart.
+
+ __Please note__: In order for the shopping_cart to function correctly, the shipment item requires a parameter ‘merchant_item_id’ with the value ‘msp-shipping'
 
 ----------------
 

--- a/content/api/payment_methods/post-order-klarna.md
+++ b/content/api/payment_methods/post-order-klarna.md
@@ -134,8 +134,6 @@ Klarna Payments (the new environment of Klarna) is available as a Redirect reque
 
 * All parameters shown are required field(s)
 
-{{< alert-notice >}} __Please note__: In order for the shopping_cart to work correctly, the shipment item requires a special 'merchant_item_id'. This parameter is called 'msp-shipping' and can be seen in the JSON code. {{< /alert-notice >}}
-
 **Parameters**
 
 ----------------
@@ -188,7 +186,9 @@ Contains the delivery information for the shipment. _Values for first_name and l
 
 __shopping_cart__ | object
 
-Contains all purchased items including tax class. If you are using your own integration, the transaction should be sent including the complete specification of the shopping_cart. 
+Contains all purchased items including tax class. If you are using your own integration, the transaction should be sent including the complete specification of the shopping_cart.
+
+ __Please note__: In order for the shopping_cart to function correctly, the shipment item requires a parameter ‘merchant_item_id’ with the value ‘msp-shipping'
 
 ----------------
 
@@ -252,8 +252,6 @@ Please note this request is for Klarna Payments. This request can only be proces
 
 * All parameters shown are required field(s)
 
-{{< alert-notice >}} __Please note__: In order for the shopping_cart to work correctly, the shipment item requires a special 'merchant_item_id'. This parameter is called 'msp-shipping' and can be seen in the JSON code. {{< /alert-notice >}}
-
 
 **Parameters**
 
@@ -313,6 +311,8 @@ Contains the delivery information for the shipment. _Values for first_name and l
 __shopping_cart__ | object
 
 Contains all purchased items including tax class. If you are using your own integration, the transaction should be sent including the complete specification of the shopping_cart. 
+
+ __Please note__: In order for the shopping_cart to function correctly, the shipment item requires a parameter ‘merchant_item_id’ with the value ‘msp-shipping'
 
 ----------------
 

--- a/content/api/payment_methods/post-order-payafter.md
+++ b/content/api/payment_methods/post-order-payafter.md
@@ -212,9 +212,6 @@ Creates a Pay After Delivery [Redirect](/faq/api/difference-between-direct-and-r
 
 * All parameters shown are required field(s)
 
-{{< alert-notice >}} __Please note__: In order for the shopping_cart to work correctly, the shipment item requires a special 'merchant_item_id'. This parameter is called 'msp-shipping' and can be seen in the JSON code. {{< /alert-notice >}}
-
-
 **Parameters**
 
 ----------------
@@ -271,7 +268,9 @@ Contains the delivery information for the shipment. _Values for first_name and l
 
 __shopping_cart__ | object
 
-Contains all purchased items including tax class. If you are using your own integration, the transaction should be sent including the complete specification of the shopping_cart. 
+Contains all purchased items including tax class. If you are using your own integration, the transaction should be sent including the complete specification of the shopping_cart.
+
+ __Please note__: In order for the shopping_cart to function correctly, the shipment item requires a parameter ‘merchant_item_id’ with the value ‘msp-shipping'
 
 ----------------
 
@@ -335,9 +334,6 @@ Creates a Pay After Delivery [Direct](/faq/api/difference-between-direct-and-red
 
 * All parameters shown are required field(s)
 
-{{< alert-notice >}} __Please note__: In order for the shopping_cart to work correctly, the shipment item requires a special 'merchant_item_id'. This parameter is called 'msp-shipping' and can be seen in the JSON code. {{< /alert-notice >}}
-
-
 **Parameters**
 
 ----------------
@@ -394,6 +390,8 @@ Contains the delivery information for the shipment. _Values for first_name and l
 __shopping_cart__ | object
 
 Contains all purchased items including tax class. If you are using your own integration, the transaction should be sent including the complete specification of the shopping_cart. 
+
+ __Please note__: In order for the shopping_cart to function correctly, the shipment item requires a parameter ‘merchant_item_id’ with the value ‘msp-shipping'
 
 ----------------
 

--- a/content/api/payment_methods/post_order_afterpay.md
+++ b/content/api/payment_methods/post_order_afterpay.md
@@ -198,8 +198,6 @@ Creates an AfterPay [Direct](/faq/api/difference-between-direct-and-redirect) or
 
 * All parameters shown are required field(s)
 
-{{< alert-notice >}} __Please note__: In order for the shopping_cart to work correctly, the shipment item requires a special 'merchant_item_id'. This parameter is called 'msp-shipping' and can be seen in the JSON code. {{< /alert-notice >}}
-
 **Parameters**
 
 ----------------
@@ -251,6 +249,8 @@ Contains the delivery information for the shipment. _Values for first_name and l
 __shopping_cart__ | object
 
 Contains all purchased items including tax class. If you are using your own integration, the transaction should be sent including the complete specification of the shopping_cart.
+
+ __Please note__: In order for the shopping_cart to function correctly, the shipment item requires a parameter ‘merchant_item_id’ with the value ‘msp-shipping'
 
 ----------------
 
@@ -314,9 +314,6 @@ Creates an AfterPay [Redirect](/faq/api/difference-between-direct-and-redirect) 
 
 * All parameters shown are required field(s)
 
-{{< alert-notice >}} __Please note__: In order for the shopping_cart to work correctly, the shipment item requires a special 'merchant_item_id'. This parameter is called 'msp-shipping' and can be seen in the JSON code. {{< /alert-notice >}}
-
-
 **Parameters**
 
 ----------------
@@ -369,6 +366,8 @@ Contains the delivery information for the shipment. _Values for first_name and l
 __shopping_cart__ | object
 
 Contains all purchased items including tax class. If you are using your own integration, the transaction should be sent including the complete specification of the shopping_cart.
+
+ __Please note__: In order for the shopping_cart to function correctly, the shipment item requires a parameter ‘merchant_item_id’ with the value ‘msp-shipping'
 
 ----------------
 


### PR DESCRIPTION
Previous branch had merge conflicts.

### Basic
- We only accept documentation that is proven to work on our LIVE API
- At least one approval is needed before pull requests can be merged
- All content is written in US English
- The terminology used must be in accordance with our naming conventions

### Text style
- Paths are formatted like: _Configuration → System → Plugin → MultiSafepay_
- Use single quotation marks in the front matter of markdown files (e.g., title: 'Title of the article')
- Use _italics_ when describing GUI elements (e.g., buttons, links and paths)
- When a sentence ends with an email address, don't use a period (e.g. "[...] contact us at <example@example.com>")

### Images
- Screenshot recommended sizes: Width: 820px - Height: auto

### Aliases
- When renaming or deleting a page, add an alias of the deprecated URL to the page users should be redirected to. This prevents external links from returning 404 errors. Check the [Hugo Documentation](https://gohugo.io/content-management/urls/#aliases) for more information.
