### PR TITLE
DOCS-2446: Fix typos in WooCommerce generic gateway FAQ item texts

### DIFF
--- a/content/integrations/ecommerce-integrations/woocommerce/faq/configuring-generic-gateways.md
+++ b/content/integrations/ecommerce-integrations/woocommerce/faq/configuring-generic-gateways.md
@@ -11,16 +11,15 @@ To configure the generic gateway, follow these steps:
 
 1. Log in to your WooCommerce backend.
 2. Go to **Settings** > **Payments** tab. All payment methods are listed here.
-3. Set theL  
-  - Gateway code
-  - Gateway logo
-  - Gateway label
-  - For billing suites, whether to include the shopping cart in refunds (**required**)
+3. Select Generic Gateway and set:
+   * Gateway code
+   * Gateway logo
+   * Gateway label
+   * For billing suites, whether to include the shopping cart in refunds (**required**)
 
-- You can filter the generic gateway by:
-
+You can filter the generic gateway by:
   - Country
   - Minimum amount
   - Maximum amount
-- You can also set a custom initial order status.
-- Full refunds, partial refunds (except for billing suites), and backend orders are fully supported.
+  - You can also set a custom initial order status.
+  - Full refunds, partial refunds (except for billing suites), and backend orders are fully supported.

--- a/content/integrations/ecommerce-integrations/woocommerce/faq/configuring-generic-gateways.md
+++ b/content/integrations/ecommerce-integrations/woocommerce/faq/configuring-generic-gateways.md
@@ -22,4 +22,4 @@ You can filter the generic gateway by:
   - Minimum amount
   - Maximum amount
 - You can also set a custom initial order status.
-  - Full refunds, partial refunds (except for billing suites), and backend orders are fully supported.
+- Full refunds, partial refunds (except for billing suites), and backend orders are fully supported.

--- a/content/integrations/ecommerce-integrations/woocommerce/faq/configuring-generic-gateways.md
+++ b/content/integrations/ecommerce-integrations/woocommerce/faq/configuring-generic-gateways.md
@@ -21,5 +21,5 @@ You can filter the generic gateway by:
   - Country
   - Minimum amount
   - Maximum amount
-  - You can also set a custom initial order status.
+- You can also set a custom initial order status.
   - Full refunds, partial refunds (except for billing suites), and backend orders are fully supported.

--- a/content/integrations/ecommerce-integrations/woocommerce/faq/configuring-generic-gateways.md
+++ b/content/integrations/ecommerce-integrations/woocommerce/faq/configuring-generic-gateways.md
@@ -11,7 +11,7 @@ To configure the generic gateway, follow these steps:
 
 1. Log in to your WooCommerce backend.
 2. Go to **Settings** > **Payments** tab. All payment methods are listed here.
-3. Select Generic Gateway and set:
+3. Select **Generic gateway** and set:
    * Gateway code
    * Gateway logo
    * Gateway label


### PR DESCRIPTION
There was a typo in the texts of the generic gateway, within the WooCommerce section.  Also change a little bit the format.