### PR TITLE
DOCS-2612: Add LightSpeed to AfterPay Activation

### DIFF
--- a/content/payments/methods/billing-suite/afterpay/activation.md
+++ b/content/payments/methods/billing-suite/afterpay/activation.md
@@ -22,12 +22,13 @@ For existing AfterPay clients, to activate AfterPay in your MultiSafepay account
 
 | Ecommerce integration | Available from  | Released  |
 |---|---|---|
-| [Magento 1](/payments/integrations/ecommerce-platforms/magento1/changelog)  | Version 2.4.1.  | May 25, 2018  | 
-| [Magento 2](https://github.com/MultiSafepay/Magento2Msp/blob/master/CHANGELOG.md)  | Version 1.5.0.  | May 5, 2018  |
-| [WooCommerce](https://github.com/MultiSafepay/WooCommerce/blob/master/CHANGELOG.md)  | Version 3.1.0.  | June 15, 2018  |
-| [OpenCart](https://github.com/MultiSafepay/Opencart/blob/master/CHANGELOG.md)  | Version 2.2.0.  | June 15, 2018  |
-| [PrestaShop 1.7](https://github.com/MultiSafepay/PrestaShop/blob/master/CHANGELOG.md)  | Version 4.2.0.  | May 25, 2018  |
-| [CS-Cart](https://github.com/MultiSafepay/CS-Cart/blob/master/CHANGELOG.md)  | Version 1.3.0.  | October 8, 2018  |
-| [X-Cart](/payments/integrations/ecommerce-platforms/x-cart)  | Version 2.2.0.  | April 24, 2019  |
+| [Magento 1](/payments/integrations/ecommerce-platforms/magento1/changelog)  | Version 2.4.1  | May 25, 2018  | 
+| [Magento 2](https://github.com/MultiSafepay/Magento2Msp/blob/master/CHANGELOG.md)  | Version 1.5.0  | May 5, 2018  |
+| [WooCommerce](https://github.com/MultiSafepay/WooCommerce/blob/master/CHANGELOG.md)  | Version 3.1.0  | June 15, 2018  |
+| [LightSpeed](/ecommerce-platforms/lightspeed/)  | Version 1.0  |   |
+| [OpenCart](https://github.com/MultiSafepay/Opencart/blob/master/CHANGELOG.md)  | Version 2.2.0  | June 15, 2018  |
+| [PrestaShop 1.7](https://github.com/MultiSafepay/PrestaShop/blob/master/CHANGELOG.md)  | Version 4.2.0  | May 25, 2018  |
+| [CS-Cart](https://github.com/MultiSafepay/CS-Cart/blob/master/CHANGELOG.md)  | Version 1.3.0  | October 8, 2018  |
+| [X-Cart](/payments/integrations/ecommerce-platforms/x-cart)  | Version 2.2.0  | April 24, 2019  |
 
 {{< /details >}}


### PR DESCRIPTION
Do the changes meet MultiSafepay Docs' Definition of Done?
- Style guide, tone of voice, and naming conventions
- Tested
- Reviewed on mobile, tablet and desktop screens
- Notified stakeholders
- Pass GitHub Actions
