### PR TITLE
DOCS-2710: Remove SEPA from Shopify payment methods

### DIFF
--- a/content/payments/integrations/ecommerce-platforms/ccvshop/faq/supported-payment-methods.md
+++ b/content/payments/integrations/ecommerce-platforms/ccvshop/faq/supported-payment-methods.md
@@ -10,20 +10,20 @@ aliases:
 
 {{< details title="Credit cards" >}}
   
-+ [American Express](/payments/methods/credit-and-debit-cards/american-express)
-+ [Mastercard](/payments/methods/credit-and-debit-cards/mastercard)
-+ [Visa](/payments/methods/credit-and-debit-cards/visa), including [Cartes Bancaires](/payments/methods/credit-and-debit-cards/cartes-bancaires) & [Dankort](/payments/methods/credit-and-debit-cards/dankort)
+- [American Express](/payments/methods/credit-and-debit-cards/american-express)
+- [Mastercard](/payments/methods/credit-and-debit-cards/mastercard)
+- [Visa](/payments/methods/credit-and-debit-cards/visa), including [Cartes Bancaires](/payments/methods/credit-and-debit-cards/cartes-bancaires) & [Dankort](/payments/methods/credit-and-debit-cards/dankort)
 
 {{< /details >}}
 
 {{< details title="Banking methods" >}}
 
-+ [Bancontact](/payments/methods/banks/bancontact)
-+ [Bank transfer](/payments/methods/banks/bank-transfer)
-+ [Giropay](/payments/methods/banks/giropay)
-+ [iDEAL](/payments/methods/banks/ideal)
-+ [SOFORT Banking](/payments/methods/banks/sofort-banking)
-+ [Trustly](/payments/methods/banks/trustly)
+- [Bancontact](/payments/methods/banks/bancontact)
+- [Bank transfer](/payments/methods/banks/bank-transfer)
+- [Giropay](/payments/methods/banks/giropay)
+- [iDEAL](/payments/methods/banks/ideal)
+- [SOFORT Banking](/payments/methods/banks/sofort-banking)
+- [Trustly](/payments/methods/banks/trustly)
 
 {{< /details >}}
 

--- a/content/payments/integrations/ecommerce-platforms/craftcommerce/faq/supported-payment-methods.md
+++ b/content/payments/integrations/ecommerce-platforms/craftcommerce/faq/supported-payment-methods.md
@@ -11,29 +11,29 @@ aliases:
 
 {{< details title="Credit cards" >}}
 
-+ [American Express](/payments/methods/credit-and-debit-cards/american-express)
-+ [Mastercard](/payments/methods/credit-and-debit-cards/mastercard)
-+ [Visa](/payments/methods/credit-and-debit-cards/visa), including [Cartes Bancaires](/payments/methods/credit-and-debit-cards/cartes-bancaires) & [Dankort](/payments/methods/credit-and-debit-cards/dankort)
+- [American Express](/payments/methods/credit-and-debit-cards/american-express)
+- [Mastercard](/payments/methods/credit-and-debit-cards/mastercard)
+- [Visa](/payments/methods/credit-and-debit-cards/visa), including [Cartes Bancaires](/payments/methods/credit-and-debit-cards/cartes-bancaires) & [Dankort](/payments/methods/credit-and-debit-cards/dankort)
 
 {{< /details >}}
 
 {{< details title="Banking methods" >}}
 
-+ [Bancontact](/payments/methods/banks/bancontact)
-+ [Bank transfer](/payments/methods/banks/bank-transfer)
-+ [Belfius](/payments/methods/banks/belfius)
-+ [Dotpay](/payments/methods/banks/dotpay)
-+ [EPS](/payments/methods/banks/eps)
-+ [Giropay](/payments/methods/banks/giropay)
-+ [iDEAL](/payments/methods/banks/ideal)
-+ [iDEAL QR](/payments/methods/banks/idealqr)
-+ [ING Home'Pay](/payments/methods/banks/ing-home-pay)
-+ [KBC](/payments/methods/banks/kbc)
-+ [Maestro](/payments/methods/credit-and-debit-cards/maestro)
-+ [Request to Pay](/payments/methods/banks/request-to-pay)
+- [Bancontact](/payments/methods/banks/bancontact)
+- [Bank transfer](/payments/methods/banks/bank-transfer)
+- [Belfius](/payments/methods/banks/belfius)
+- [Dotpay](/payments/methods/banks/dotpay)
+- [EPS](/payments/methods/banks/eps)
+- [Giropay](/payments/methods/banks/giropay)
+- [iDEAL](/payments/methods/banks/ideal)
+- [iDEAL QR](/payments/methods/banks/idealqr)
+- [ING Home'Pay](/payments/methods/banks/ing-home-pay)
+- [KBC](/payments/methods/banks/kbc)
+- [Maestro](/payments/methods/credit-and-debit-cards/maestro)
+- [Request to Pay](/payments/methods/banks/request-to-pay)
 + [SEPA Direct Debit](/payments/methods/banks/sepa-direct-debit)
-+ [SOFORT Banking](/payments/methods/banks/sofort-banking)
-+ [Trustly](/payments/methods/banks/trustly)
+- [SOFORT Banking](/payments/methods/banks/sofort-banking)
+- [Trustly](/payments/methods/banks/trustly)
 + [TrustPay](/payments/methods/banks/trustpay)
 
 {{< /details >}}

--- a/content/payments/integrations/ecommerce-platforms/cs-cart/faq/supported-payment-methods.md
+++ b/content/payments/integrations/ecommerce-platforms/cs-cart/faq/supported-payment-methods.md
@@ -11,30 +11,30 @@ aliases:
 
 {{< details title="Credit cards" >}}
 
-+ [American Express](/payments/methods/credit-and-debit-cards/american-express)
-+ [Mastercard](/payments/methods/credit-and-debit-cards/mastercard)
-+ [Visa](/payments/methods/credit-and-debit-cards/visa), including [Cartes Bancaires](/payments/methods/credit-and-debit-cards/cartes-bancaires) & [Dankort](/payments/methods/credit-and-debit-cards/dankort)
+- [American Express](/payments/methods/credit-and-debit-cards/american-express)
+- [Mastercard](/payments/methods/credit-and-debit-cards/mastercard)
+- [Visa](/payments/methods/credit-and-debit-cards/visa), including [Cartes Bancaires](/payments/methods/credit-and-debit-cards/cartes-bancaires) & [Dankort](/payments/methods/credit-and-debit-cards/dankort)
 
 {{< /details >}}
 
 {{< details title="Banking methods" >}}
 
-+ [Bancontact](/payments/methods/banks/bancontact)
-+ [Bank transfer](/payments/methods/banks/bank-transfer)
-+ [Belfius](/payments/methods/banks/belfius)
+- [Bancontact](/payments/methods/banks/bancontact)
+- [Bank transfer](/payments/methods/banks/bank-transfer)
+- [Belfius](/payments/methods/banks/belfius)
 + [CBC](/payments/methods/banks/cbc)
-+ [Dotpay](/payments/methods/banks/dotpay)
-+ [EPS](/payments/methods/banks/eps)
-+ [Giropay](/payments/methods/banks/giropay)
-+ [iDEAL](/payments/methods/banks/ideal)
-+ [iDEAL QR](/payments/methods/banks/idealqr)
-+ [ING Home'Pay](/payments/methods/banks/ing-home-pay)
-+ [KBC](/payments/methods/banks/kbc)
-+ [Maestro](/payments/methods/credit-and-debit-cards/maestro)
-+ [Request to Pay](/payments/methods/banks/request-to-pay)
+- [Dotpay](/payments/methods/banks/dotpay)
+- [EPS](/payments/methods/banks/eps)
+- [Giropay](/payments/methods/banks/giropay)
+- [iDEAL](/payments/methods/banks/ideal)
+- [iDEAL QR](/payments/methods/banks/idealqr)
+- [ING Home'Pay](/payments/methods/banks/ing-home-pay)
+- [KBC](/payments/methods/banks/kbc)
+- [Maestro](/payments/methods/credit-and-debit-cards/maestro)
+- [Request to Pay](/payments/methods/banks/request-to-pay)
 + [SEPA Direct Debit](/payments/methods/banks/sepa-direct-debit)
-+ [SOFORT Banking](/payments/methods/banks/sofort-banking)
-+ [Trustly](/payments/methods/banks/trustly)
+- [SOFORT Banking](/payments/methods/banks/sofort-banking)
+- [Trustly](/payments/methods/banks/trustly)
 + [TrustPay](/payments/methods/banks/trustpay)
 + [V PAY](/payments/methods/credit-and-debit-cards/vpay)
 

--- a/content/payments/integrations/ecommerce-platforms/drupal7/faq/supported-payment-methods.md
+++ b/content/payments/integrations/ecommerce-platforms/drupal7/faq/supported-payment-methods.md
@@ -9,27 +9,27 @@ aliases:
 ---
 {{< details title="Credit cards" >}}
 
-+ [American Express](/payments/methods/credit-and-debit-cards/american-express)
-+ [Mastercard](/payments/methods/credit-and-debit-cards/mastercard)
-+ [Visa](/payments/methods/credit-and-debit-cards/visa), including [Cartes Bancaires](/payments/methods/credit-and-debit-cards/cartes-bancaires) & [Dankort](/payments/methods/credit-and-debit-cards/dankort)
+- [American Express](/payments/methods/credit-and-debit-cards/american-express)
+- [Mastercard](/payments/methods/credit-and-debit-cards/mastercard)
+- [Visa](/payments/methods/credit-and-debit-cards/visa), including [Cartes Bancaires](/payments/methods/credit-and-debit-cards/cartes-bancaires) & [Dankort](/payments/methods/credit-and-debit-cards/dankort)
 
 {{< /details >}}
 
 {{< details title="Banking methods" >}}
 
-+ [Bancontact](/payments/methods/banks/bancontact)
-+ [Bank transfer](/payments/methods/banks/bank-transfer)
-+ [Belfius](/payments/methods/banks/belfius)
-+ [Dotpay](/payments/methods/banks/dotpay)
-+ [EPS](/payments/methods/banks/eps)
-+ [Giropay](/payments/methods/banks/giropay)
-+ [iDEAL](/payments/methods/banks/ideal)
-+ [ING Home'Pay](/payments/methods/banks/ing-home-pay)
-+ [KBC](/payments/methods/banks/kbc)
-+ [Maestro](/payments/methods/credit-and-debit-cards/maestro)
-+ [Request to Pay](/payments/methods/banks/request-to-pay)
+- [Bancontact](/payments/methods/banks/bancontact)
+- [Bank transfer](/payments/methods/banks/bank-transfer)
+- [Belfius](/payments/methods/banks/belfius)
+- [Dotpay](/payments/methods/banks/dotpay)
+- [EPS](/payments/methods/banks/eps)
+- [Giropay](/payments/methods/banks/giropay)
+- [iDEAL](/payments/methods/banks/ideal)
+- [ING Home'Pay](/payments/methods/banks/ing-home-pay)
+- [KBC](/payments/methods/banks/kbc)
+- [Maestro](/payments/methods/credit-and-debit-cards/maestro)
+- [Request to Pay](/payments/methods/banks/request-to-pay)
 + [SEPA Direct Debit](/payments/methods/banks/sepa-direct-debit)
-+ [SOFORT Banking](/payments/methods/banks/sofort-banking)
+- [SOFORT Banking](/payments/methods/banks/sofort-banking)
 + [TrustPay](/payments/methods/banks/trustpay)
 + [V PAY](/payments/methods/credit-and-debit-cards/vpay)
 

--- a/content/payments/integrations/ecommerce-platforms/drupal8/faq/supported-payment-methods.md
+++ b/content/payments/integrations/ecommerce-platforms/drupal8/faq/supported-payment-methods.md
@@ -10,29 +10,29 @@ aliases:
 ---
 {{< details title="Credit cards" >}}
 
-+ [American Express](/payments/methods/credit-and-debit-cards/american-express)
-+ [Mastercard](/payments/methods/credit-and-debit-cards/mastercard)
-+ [Visa](/payments/methods/credit-and-debit-cards/visa), including [Cartes Bancaires](/payments/methods/credit-and-debit-cards/cartes-bancaires) & [Dankort](/payments/methods/credit-and-debit-cards/dankort)
+- [American Express](/payments/methods/credit-and-debit-cards/american-express)
+- [Mastercard](/payments/methods/credit-and-debit-cards/mastercard)
+- [Visa](/payments/methods/credit-and-debit-cards/visa), including [Cartes Bancaires](/payments/methods/credit-and-debit-cards/cartes-bancaires) & [Dankort](/payments/methods/credit-and-debit-cards/dankort)
 
 {{< /details >}}
 
 {{< details title="Banking methods" >}}
 
-+ [Bancontact](/payments/methods/banks/bancontact)
-+ [Bank transfer](/payments/methods/banks/bank-transfer)
-+ [Belfius](/payments/methods/banks/belfius)
-+ [Dotpay](/payments/methods/banks/dotpay)
-+ [EPS](/payments/methods/banks/eps)
-+ [Giropay](/payments/methods/banks/giropay)
-+ [iDEAL](/payments/methods/banks/ideal)
-+ [iDEAL QR](/payments/methods/banks/idealqr)
-+ [ING Home'Pay](/payments/methods/banks/ing-home-pay)
-+ [KBC](/payments/methods/banks/kbc)
-+ [Maestro](/payments/methods/credit-and-debit-cards/maestro)
-+ [Request to Pay](/payments/methods/banks/request-to-pay)
+- [Bancontact](/payments/methods/banks/bancontact)
+- [Bank transfer](/payments/methods/banks/bank-transfer)
+- [Belfius](/payments/methods/banks/belfius)
+- [Dotpay](/payments/methods/banks/dotpay)
+- [EPS](/payments/methods/banks/eps)
+- [Giropay](/payments/methods/banks/giropay)
+- [iDEAL](/payments/methods/banks/ideal)
+- [iDEAL QR](/payments/methods/banks/idealqr)
+- [ING Home'Pay](/payments/methods/banks/ing-home-pay)
+- [KBC](/payments/methods/banks/kbc)
+- [Maestro](/payments/methods/credit-and-debit-cards/maestro)
+- [Request to Pay](/payments/methods/banks/request-to-pay)
 + [SEPA Direct Debit](/payments/methods/banks/sepa-direct-debit)
-+ [SOFORT Banking](/payments/methods/banks/sofort-banking)
-+ [Trustly](/payments/methods/banks/trustly)
+- [SOFORT Banking](/payments/methods/banks/sofort-banking)
+- [Trustly](/payments/methods/banks/trustly)
 + [TrustPay](/payments/methods/banks/trustpay)
 + [V PAY](/payments/methods/credit-and-debit-cards/vpay)
 

--- a/content/payments/integrations/ecommerce-platforms/ecwid/faq/supported-payment-methods.md
+++ b/content/payments/integrations/ecommerce-platforms/ecwid/faq/supported-payment-methods.md
@@ -10,19 +10,19 @@ aliases:
 
 {{< details title="Credit cards" >}}
 
-+ [American Express](/payments/methods/credit-and-debit-cards/american-express)
-+ [Mastercard](/payments/methods/credit-and-debit-cards/mastercard)
-+ [Visa](/payments/methods/credit-and-debit-cards/visa), including [Cartes Bancaires](/payments/methods/credit-and-debit-cards/cartes-bancaires) & [Dankort](/payments/methods/credit-and-debit-cards/dankort)
+- [American Express](/payments/methods/credit-and-debit-cards/american-express)
+- [Mastercard](/payments/methods/credit-and-debit-cards/mastercard)
+- [Visa](/payments/methods/credit-and-debit-cards/visa), including [Cartes Bancaires](/payments/methods/credit-and-debit-cards/cartes-bancaires) & [Dankort](/payments/methods/credit-and-debit-cards/dankort)
 
 {{< /details >}}
 
 {{< details title="Banking methods" >}}
 
-+ [Bancontact](/payments/methods/banks/bancontact)
-+ [Bank transfer](/payments/methods/banks/bank-transfer)
-+ [Giropay](/payments/methods/banks/giropay)
-+ [iDEAL](/payments/methods/banks/ideal)
+- [Bancontact](/payments/methods/banks/bancontact)
+- [Bank transfer](/payments/methods/banks/bank-transfer)
+- [Giropay](/payments/methods/banks/giropay)
+- [iDEAL](/payments/methods/banks/ideal)
 + [SEPA Direct Debit](/payments/methods/banks/sepa-direct-debit)
-+ [SOFORT Banking](/payments/methods/banks/sofort-banking)
+- [SOFORT Banking](/payments/methods/banks/sofort-banking)
 
 {{< /details >}}

--- a/content/payments/integrations/ecommerce-platforms/lightspeed_app/faq/supported-payment-methods.md
+++ b/content/payments/integrations/ecommerce-platforms/lightspeed_app/faq/supported-payment-methods.md
@@ -9,27 +9,27 @@ aliases:
 ---
 
 {{< details title="Credit cards" >}}
-+ [American Express](/payments/methods/credit-and-debit-cards/american-express)
-+ [Mastercard](/payments/methods/credit-and-debit-cards/mastercard)
-+ [Visa](/payments/methods/credit-and-debit-cards/visa), including [Cartes Bancaires](/payments/methods/credit-and-debit-cards/cartes-bancaires) and [Dankort](/payments/methods/credit-and-debit-cards/dankort) 
+- [American Express](/payments/methods/credit-and-debit-cards/american-express)
+- [Mastercard](/payments/methods/credit-and-debit-cards/mastercard)
+- [Visa](/payments/methods/credit-and-debit-cards/visa), including [Cartes Bancaires](/payments/methods/credit-and-debit-cards/cartes-bancaires) and [Dankort](/payments/methods/credit-and-debit-cards/dankort) 
 {{< /details >}}
 
 {{< details title="Banking methods" >}}
-+ [Bancontact](/payments/methods/banks/bancontact)
-+ [Bank transfer](/payments/methods/banks/bank-transfer)
-+ [Belfius](/payments/methods/banks/belfius)
+- [Bancontact](/payments/methods/banks/bancontact)
+- [Bank transfer](/payments/methods/banks/bank-transfer)
+- [Belfius](/payments/methods/banks/belfius)
 + [CBC](/payments/methods/banks/cbc)
-+ [Dotpay](/payments/methods/banks/dotpay)
-+ [EPS](/payments/methods/banks/eps)
-+ [Giropay](/payments/methods/banks/giropay)
-+ [iDEAL](/payments/methods/banks/ideal)
-+ [ING Home'Pay](/payments/methods/banks/ing-home-pay)
-+ [KBC](/payments/methods/banks/kbc)
-+ [Maestro](/payments/methods/credit-and-debit-cards/maestro)
-+ [Request to Pay](/payments/methods/banks/request-to-pay)
+- [Dotpay](/payments/methods/banks/dotpay)
+- [EPS](/payments/methods/banks/eps)
+- [Giropay](/payments/methods/banks/giropay)
+- [iDEAL](/payments/methods/banks/ideal)
+- [ING Home'Pay](/payments/methods/banks/ing-home-pay)
+- [KBC](/payments/methods/banks/kbc)
+- [Maestro](/payments/methods/credit-and-debit-cards/maestro)
+- [Request to Pay](/payments/methods/banks/request-to-pay)
 + [SEPA Direct Debit](/payments/methods/banks/sepa-direct-debit)
-+ [SOFORT Banking](/payments/methods/banks/sofort-banking)
-+ [Trustly](/payments/methods/banks/trustly) 
+- [SOFORT Banking](/payments/methods/banks/sofort-banking)
+- [Trustly](/payments/methods/banks/trustly) 
 {{< /details >}}
 
 {{< details title="Billing Suite" >}}

--- a/content/payments/integrations/ecommerce-platforms/lightspeed_app/lightspeed_core/faq/supported-payment-methods-.md
+++ b/content/payments/integrations/ecommerce-platforms/lightspeed_app/lightspeed_core/faq/supported-payment-methods-.md
@@ -8,23 +8,23 @@ aliases:
     - /integrations/lightspeed/faq/available-payment-methods-lightspeed/
 
 ---
-+ [American Express](/payments/methods/credit-and-debit-cards/american-express)
-+ [Bancontact](/payments/methods/banks/bancontact)
-+ [Bank transfer](/payments/methods/banks/bank-transfer)
-+ [Belfius](/payments/methods/banks/belfius)
+- [American Express](/payments/methods/credit-and-debit-cards/american-express)
+- [Bancontact](/payments/methods/banks/bancontact)
+- [Bank transfer](/payments/methods/banks/bank-transfer)
+- [Belfius](/payments/methods/banks/belfius)
 + [SEPA Direct Debit](/payments/methods/banks/sepa-direct-debit)
-+ [Dotpay](/payments/methods/banks/dotpay)
-+ [EPS](/payments/methods/banks/eps)
-+ [Giropay](/payments/methods/banks/giropay)
-+ [iDEAL](/payments/methods/banks/ideal)
+- [Dotpay](/payments/methods/banks/dotpay)
+- [EPS](/payments/methods/banks/eps)
+- [Giropay](/payments/methods/banks/giropay)
+- [iDEAL](/payments/methods/banks/ideal)
 + [in3](https://docs.multisafepay.com/payment-methods/billing-suite/in3)
-+ [ING Home'Pay](/payments/methods/banks/ing-home-pay)
-+ [KBC](/payments/methods/banks/kbc)
-+ [Maestro](/payments/methods/credit-and-debit-cards/maestro)
-+ [Mastercard](/payments/methods/credit-and-debit-cards/mastercard)
+- [ING Home'Pay](/payments/methods/banks/ing-home-pay)
+- [KBC](/payments/methods/banks/kbc)
+- [Maestro](/payments/methods/credit-and-debit-cards/maestro)
+- [Mastercard](/payments/methods/credit-and-debit-cards/mastercard)
 + [PayPal](/payments/methods/wallet/paypal)
-+ [SOFORT Banking](/payments/methods/banks/sofort-banking)
-+ [Visa](/payments/methods/credit-and-debit-cards/visa), including [Cartes Bancaires](/payments/methods/credit-and-debit-cards/cartes-bancaires) & [Dankort](/payments/methods/credit-and-debit-cards/dankort)
+- [SOFORT Banking](/payments/methods/banks/sofort-banking)
+- [Visa](/payments/methods/credit-and-debit-cards/visa), including [Cartes Bancaires](/payments/methods/credit-and-debit-cards/cartes-bancaires) & [Dankort](/payments/methods/credit-and-debit-cards/dankort)
 
 
 **Gift cards**

--- a/content/payments/integrations/ecommerce-platforms/logic4/faq/supported-payment-methods.md
+++ b/content/payments/integrations/ecommerce-platforms/logic4/faq/supported-payment-methods.md
@@ -9,28 +9,28 @@ aliases:
 
 {{< details title="Credit cards" >}}
 
-+ [American Express](/payments/methods/credit-and-debit-cards/american-express)
-+ [Mastercard](/payments/methods/credit-and-debit-cards/mastercard)
-+ [Visa](/payments/methods/credit-and-debit-cards/visa)
+- [American Express](/payments/methods/credit-and-debit-cards/american-express)
+- [Mastercard](/payments/methods/credit-and-debit-cards/mastercard)
+- [Visa](/payments/methods/credit-and-debit-cards/visa)
 
 {{< /details >}}
 
 {{< details title="Banking methods" >}}
 
-+ [Bancontact](/payments/methods/banks/bancontact)
-+ [Bank transfer](/payments/methods/banks/bank-transfer)
-+ [Belfius](/payments/methods/banks/belfius)
-+ [EPS](/payments/methods/banks/eps)
-+ [Giropay](/payments/methods/banks/giropay)
-+ [iDEAL](/payments/methods/banks/ideal)
-+ [iDEAL QR](/payments/methods/banks/idealqr)
-+ [ING Home'Pay](/payments/methods/banks/ing-home-pay)
-+ [KBC](/payments/methods/banks/kbc)
-+ [Maestro](/payments/methods/credit-and-debit-cards/maestro)
+- [Bancontact](/payments/methods/banks/bancontact)
+- [Bank transfer](/payments/methods/banks/bank-transfer)
+- [Belfius](/payments/methods/banks/belfius)
+- [EPS](/payments/methods/banks/eps)
+- [Giropay](/payments/methods/banks/giropay)
+- [iDEAL](/payments/methods/banks/ideal)
+- [iDEAL QR](/payments/methods/banks/idealqr)
+- [ING Home'Pay](/payments/methods/banks/ing-home-pay)
+- [KBC](/payments/methods/banks/kbc)
+- [Maestro](/payments/methods/credit-and-debit-cards/maestro)
 + MultiSafepay Wallet
 + [PayPal](/payments/methods/wallet/paypal)
-+ [SOFORT Banking](/payments/methods/banks/sofort-banking)
-+ [Trustly](/payments/methods/banks/trustly)
+- [SOFORT Banking](/payments/methods/banks/sofort-banking)
+- [Trustly](/payments/methods/banks/trustly)
 
 {{< /details >}}
 

--- a/content/payments/integrations/ecommerce-platforms/logivert/faq/supported-payment-methods.md
+++ b/content/payments/integrations/ecommerce-platforms/logivert/faq/supported-payment-methods.md
@@ -9,20 +9,20 @@ aliases:
 
 {{< details title="Credit cards" >}}
 
-+ [American Express](/payments/methods/credit-and-debit-cards/american-express)
-+ [Mastercard](/payments/methods/credit-and-debit-cards/mastercard)
-+ [Visa](/payments/methods/credit-and-debit-cards/visa), including [Cartes Bancaires](/payments/methods/credit-and-debit-cards/cartes-bancaires) & [Dankort](/payments/methods/credit-and-debit-cards/dankort)
+- [American Express](/payments/methods/credit-and-debit-cards/american-express)
+- [Mastercard](/payments/methods/credit-and-debit-cards/mastercard)
+- [Visa](/payments/methods/credit-and-debit-cards/visa), including [Cartes Bancaires](/payments/methods/credit-and-debit-cards/cartes-bancaires) & [Dankort](/payments/methods/credit-and-debit-cards/dankort)
 
 {{< /details >}}
 
 {{< details title="Banking methods" >}}
 
-+ [Bancontact](/payments/methods/banks/bancontact)
-+ [Bank transfer](/payments/methods/banks/bank-transfer)
-+ [Giropay](/payments/methods/banks/giropay)
-+ [iDEAL](/payments/methods/banks/ideal)
+- [Bancontact](/payments/methods/banks/bancontact)
+- [Bank transfer](/payments/methods/banks/bank-transfer)
+- [Giropay](/payments/methods/banks/giropay)
+- [iDEAL](/payments/methods/banks/ideal)
 + [SEPA Direct Debit](/payments/methods/banks/sepa-direct-debit)
-+ [SOFORT Banking](/payments/methods/banks/sofort-banking)
+- [SOFORT Banking](/payments/methods/banks/sofort-banking)
 
 {{< /details >}}
 

--- a/content/payments/integrations/ecommerce-platforms/magento1/faq/supported-payment-methods.md
+++ b/content/payments/integrations/ecommerce-platforms/magento1/faq/supported-payment-methods.md
@@ -10,30 +10,30 @@ aliases:
 ---
 {{< details title="Credit cards" >}}
 
-+ [American Express](/payments/methods/credit-and-debit-cards/american-express)
-+ [Mastercard](/payments/methods/credit-and-debit-cards/mastercard)
-+ [Visa](/payments/methods/credit-and-debit-cards/visa), including [Cartes Bancaires](/payments/methods/credit-and-debit-cards/cartes-bancaires) & [Dankort](/payments/methods/credit-and-debit-cards/dankort)
+- [American Express](/payments/methods/credit-and-debit-cards/american-express)
+- [Mastercard](/payments/methods/credit-and-debit-cards/mastercard)
+- [Visa](/payments/methods/credit-and-debit-cards/visa), including [Cartes Bancaires](/payments/methods/credit-and-debit-cards/cartes-bancaires) & [Dankort](/payments/methods/credit-and-debit-cards/dankort)
 
 {{< /details >}}
 
 {{< details title="Banking methods" >}}
 
-+ [Bancontact](/payments/methods/banks/bancontact)
-+ [Bank transfer](/payments/methods/banks/bank-transfer)
-+ [Belfius](/payments/methods/banks/belfius)
+- [Bancontact](/payments/methods/banks/bancontact)
+- [Bank transfer](/payments/methods/banks/bank-transfer)
+- [Belfius](/payments/methods/banks/belfius)
 + [CBC](/payments/methods/banks/cbc)
-+ [Dotpay](/payments/methods/banks/dotpay)
-+ [EPS](/payments/methods/banks/eps)
-+ [Giropay](/payments/methods/banks/giropay)
-+ [iDEAL](/payments/methods/banks/ideal)
-+ [iDEAL QR](/payments/methods/banks/idealqr)
-+ [ING Home'Pay](/payments/methods/banks/ing-home-pay)
-+ [KBC](/payments/methods/banks/kbc)
-+ [Maestro](/payments/methods/credit-and-debit-cards/maestro)
-+ [Request to Pay](/payments/methods/banks/request-to-pay)
+- [Dotpay](/payments/methods/banks/dotpay)
+- [EPS](/payments/methods/banks/eps)
+- [Giropay](/payments/methods/banks/giropay)
+- [iDEAL](/payments/methods/banks/ideal)
+- [iDEAL QR](/payments/methods/banks/idealqr)
+- [ING Home'Pay](/payments/methods/banks/ing-home-pay)
+- [KBC](/payments/methods/banks/kbc)
+- [Maestro](/payments/methods/credit-and-debit-cards/maestro)
+- [Request to Pay](/payments/methods/banks/request-to-pay)
 + [SEPA Direct Debit](/payments/methods/banks/sepa-direct-debit)
-+ [SOFORT Banking](/payments/methods/banks/sofort-banking)
-+ [Trustly](/payments/methods/banks/trustly)
+- [SOFORT Banking](/payments/methods/banks/sofort-banking)
+- [Trustly](/payments/methods/banks/trustly)
 
 {{< /details >}}
 

--- a/content/payments/integrations/ecommerce-platforms/magento2/faq/supported-payment-methods.md
+++ b/content/payments/integrations/ecommerce-platforms/magento2/faq/supported-payment-methods.md
@@ -10,30 +10,30 @@ aliases:
 ---
 {{< details title="Credit cards" >}}
 
-+ [American Express](/payments/methods/credit-and-debit-cards/american-express)
-+ [Mastercard](/payments/methods/credit-and-debit-cards/mastercard)
-+ [Visa](/payments/methods/credit-and-debit-cards/visa), including [Cartes Bancaires](/payments/methods/credit-and-debit-cards/cartes-bancaires) and [Dankort](/payments/methods/credit-and-debit-cards/dankort)
+- [American Express](/payments/methods/credit-and-debit-cards/american-express)
+- [Mastercard](/payments/methods/credit-and-debit-cards/mastercard)
+- [Visa](/payments/methods/credit-and-debit-cards/visa), including [Cartes Bancaires](/payments/methods/credit-and-debit-cards/cartes-bancaires) and [Dankort](/payments/methods/credit-and-debit-cards/dankort)
 
 {{< /details >}}
 
 {{< details title="Banking methods" >}}
 
-+ [Bancontact](/payments/methods/banks/bancontact)
-+ [Bank transfer](/payments/methods/banks/bank-transfer)
-+ [Belfius](/payments/methods/banks/belfius)
+- [Bancontact](/payments/methods/banks/bancontact)
+- [Bank transfer](/payments/methods/banks/bank-transfer)
+- [Belfius](/payments/methods/banks/belfius)
 + [CBC](/payments/methods/banks/cbc)
-+ [Dotpay](/payments/methods/banks/dotpay)
-+ [EPS](/payments/methods/banks/eps)
-+ [Giropay](/payments/methods/banks/giropay)
-+ [iDEAL](/payments/methods/banks/ideal)
-+ [iDEAL QR](/payments/methods/banks/idealqr)
-+ [ING Home'Pay](/payments/methods/banks/ing-home-pay)
-+ [KBC](/payments/methods/banks/kbc)
-+ [Maestro](/payments/methods/credit-and-debit-cards/maestro)
-+ [Request to Pay](/payments/methods/banks/request-to-pay)
+- [Dotpay](/payments/methods/banks/dotpay)
+- [EPS](/payments/methods/banks/eps)
+- [Giropay](/payments/methods/banks/giropay)
+- [iDEAL](/payments/methods/banks/ideal)
+- [iDEAL QR](/payments/methods/banks/idealqr)
+- [ING Home'Pay](/payments/methods/banks/ing-home-pay)
+- [KBC](/payments/methods/banks/kbc)
+- [Maestro](/payments/methods/credit-and-debit-cards/maestro)
+- [Request to Pay](/payments/methods/banks/request-to-pay)
 + [SEPA Direct Debit](/payments/methods/banks/sepa-direct-debit)
-+ [SOFORT Banking](/payments/methods/banks/sofort-banking)
-+ [Trustly](/payments/methods/banks/trustly)
+- [SOFORT Banking](/payments/methods/banks/sofort-banking)
+- [Trustly](/payments/methods/banks/trustly)
 + [TrustPay](/payments/methods/banks/trustpay) 
 
 {{< /details >}}

--- a/content/payments/integrations/ecommerce-platforms/magento2/old/faq/available-payment-methods-magento2.md
+++ b/content/payments/integrations/ecommerce-platforms/magento2/old/faq/available-payment-methods-magento2.md
@@ -8,29 +8,29 @@ read_more: "."
 ---
 {{< details title="Credit cards" >}}
 
-+ [American Express](/payments/methods/credit-and-debit-cards/american-express)
-+ [Mastercard](/payments/methods/credit-and-debit-cards/mastercard)
-+ [Visa](/payments/methods/credit-and-debit-cards/visa) (including [Cartes Bancaires](/payments/methods/credit-and-debit-cards/cartes-bancaires) & [Dankort](/payments/methods/credit-and-debit-cards/dankort))
+- [American Express](/payments/methods/credit-and-debit-cards/american-express)
+- [Mastercard](/payments/methods/credit-and-debit-cards/mastercard)
+- [Visa](/payments/methods/credit-and-debit-cards/visa) (including [Cartes Bancaires](/payments/methods/credit-and-debit-cards/cartes-bancaires) & [Dankort](/payments/methods/credit-and-debit-cards/dankort))
 
 {{< /details >}}
 
 {{< details title="Banking methods" >}}
 
-+ [Bancontact](/payments/methods/banks/bancontact)
-+ [Bank transfer](/payments/methods/banks/bank-transfer)
-+ [Belfius](/payments/methods/banks/belfius)
-+ [Dotpay](/payments/methods/banks/dotpay)
-+ [EPS](/payments/methods/banks/eps)
-+ [Giropay](/payments/methods/banks/giropay)
-+ [iDEAL](/payments/methods/banks/ideal)
-+ [iDEAL QR](/payments/methods/banks/idealqr)
-+ [ING Home'Pay](/payments/methods/banks/ing-home-pay)
-+ [KBC](/payments/methods/banks/kbc)
-+ [Maestro](/payments/methods/credit-and-debit-cards/maestro)
-+ [Request to Pay](/payments/methods/banks/request-to-pay)
+- [Bancontact](/payments/methods/banks/bancontact)
+- [Bank transfer](/payments/methods/banks/bank-transfer)
+- [Belfius](/payments/methods/banks/belfius)
+- [Dotpay](/payments/methods/banks/dotpay)
+- [EPS](/payments/methods/banks/eps)
+- [Giropay](/payments/methods/banks/giropay)
+- [iDEAL](/payments/methods/banks/ideal)
+- [iDEAL QR](/payments/methods/banks/idealqr)
+- [ING Home'Pay](/payments/methods/banks/ing-home-pay)
+- [KBC](/payments/methods/banks/kbc)
+- [Maestro](/payments/methods/credit-and-debit-cards/maestro)
+- [Request to Pay](/payments/methods/banks/request-to-pay)
 + [SEPA Direct Debit](/payments/methods/banks/sepa-direct-debit)
-+ [SOFORT Banking](/payments/methods/banks/sofort-banking)
-+ [Trustly](/payments/methods/banks/trustly)
+- [SOFORT Banking](/payments/methods/banks/sofort-banking)
+- [Trustly](/payments/methods/banks/trustly)
 + [TrustPay](/payments/methods/banks/trustpay)
 + [V PAY](/payments/methods/credit-and-debit-cards/vpay)
 

--- a/content/payments/integrations/ecommerce-platforms/mijnwebwinkel/faq/supported-payment-methods.md
+++ b/content/payments/integrations/ecommerce-platforms/mijnwebwinkel/faq/supported-payment-methods.md
@@ -10,20 +10,20 @@ aliases:
 
 {{< details title="Credit cards" >}}
 
-+ [Mastercard](/payments/methods/credit-and-debit-cards/mastercard)
-+ [Visa](/payments/methods/credit-and-debit-cards/mastercard/visa)
+- [Mastercard](/payments/methods/credit-and-debit-cards/mastercard)
+- [Visa](/payments/methods/credit-and-debit-cards/mastercard/visa)
 
 {{< /details >}}
 
 {{< details title="Banking methods" >}}
 
-+ [Bancontact](/payments/methods/banks/bancontact)
-+ [Bank transfer](/payments/methods/banks/bank-transfer)
-+ [Giropay](/payments/methods/banks/giropay)
-+ [iDEAL](/payments/methods/banks/ideal)
-+ [Maestro](/payments/methods/credit-and-debit-cards/maestro)
+- [Bancontact](/payments/methods/banks/bancontact)
+- [Bank transfer](/payments/methods/banks/bank-transfer)
+- [Giropay](/payments/methods/banks/giropay)
+- [iDEAL](/payments/methods/banks/ideal)
+- [Maestro](/payments/methods/credit-and-debit-cards/maestro)
 + [SEPA Direct Debit](/payments/methods/banks/sepa-direct-debit)
-+ [SOFORT Banking](/payments/methods/banks/sofort-banking)
+- [SOFORT Banking](/payments/methods/banks/sofort-banking)
 
 {{< /details >}}
 

--- a/content/payments/integrations/ecommerce-platforms/myshop/faq/supported-payment-methods.md
+++ b/content/payments/integrations/ecommerce-platforms/myshop/faq/supported-payment-methods.md
@@ -8,23 +8,23 @@ aliases:
 ---
 {{< details title="Credit cards" >}}
 
-+ [American Express](/payments/methods/credit-and-debit-cards/american-express)
-+ [Mastercard](/payments/methods/credit-and-debit-cards/mastercard)
-+ [Visa](/payments/methods/credit-and-debit-cards/visa)
+- [American Express](/payments/methods/credit-and-debit-cards/american-express)
+- [Mastercard](/payments/methods/credit-and-debit-cards/mastercard)
+- [Visa](/payments/methods/credit-and-debit-cards/visa)
 
 {{< /details >}}
 
 {{< details title="Banking methods" >}}
 
-+ [Bancontact](/payments/methods/banks/bancontact)
-+ [Bank transfer](/payments/methods/banks/bank-transfer)
-+ [Dotpay](/payments/methods/banks/dotpay)
-+ [EPS](/payments/methods/banks/eps)
-+ [Giropay](/payments/methods/banks/giropay)
-+ [iDEAL](/payments/methods/banks/ideal)
-+ [Maestro](/payments/methods/credit-and-debit-cards/maestro)
+- [Bancontact](/payments/methods/banks/bancontact)
+- [Bank transfer](/payments/methods/banks/bank-transfer)
+- [Dotpay](/payments/methods/banks/dotpay)
+- [EPS](/payments/methods/banks/eps)
+- [Giropay](/payments/methods/banks/giropay)
+- [iDEAL](/payments/methods/banks/ideal)
+- [Maestro](/payments/methods/credit-and-debit-cards/maestro)
 + [SEPA Direct Debit](/payments/methods/banks/sepa-direct-debit)
-+ [SOFORT Banking](/payments/methods/banks/sofort-banking)
+- [SOFORT Banking](/payments/methods/banks/sofort-banking)
 
 {{< /details >}}
 

--- a/content/payments/integrations/ecommerce-platforms/odoo/faq/supported-payment-methods.md
+++ b/content/payments/integrations/ecommerce-platforms/odoo/faq/supported-payment-methods.md
@@ -9,27 +9,27 @@ weight: 1
 
 {{< details title="Credit cards" >}}
 
-+ [American Express](/payments/methods/credit-and-debit-cards/american-express)
-+ [Mastercard](/payments/methods/credit-and-debit-cards/mastercard)
-+ [Visa](/payments/methods/credit-and-debit-cards/visa), including [Cartes Bancaires](/payments/methods/credit-and-debit-cards/cartes-bancaires) and [Dankort](/payments/methods/credit-and-debit-cards/dankort)
+- [American Express](/payments/methods/credit-and-debit-cards/american-express)
+- [Mastercard](/payments/methods/credit-and-debit-cards/mastercard)
+- [Visa](/payments/methods/credit-and-debit-cards/visa), including [Cartes Bancaires](/payments/methods/credit-and-debit-cards/cartes-bancaires) and [Dankort](/payments/methods/credit-and-debit-cards/dankort)
 
 {{< /details >}}
 
 {{< details title="Banking methods" >}}
 
-+ [Bancontact](/payments/methods/banks/bancontact)
-+ [Bank transfer](/payments/methods/banks/bank-transfer)
-+ [Belfius](/payments/methods/banks/belfius)
-+ [Dotpay](/payments/methods/banks/dotpay)
-+ [EPS](/payments/methods/banks/eps)
-+ [Giropay](/payments/methods/banks/giropay)
-+ [iDEAL](/payments/methods/banks/ideal)
-+ [ING Home'Pay](/payments/methods/banks/ing-home-pay)
-+ [KBC](/payments/methods/banks/kbc)
-+ [Maestro](/payments/methods/credit-and-debit-cards/maestro)
+- [Bancontact](/payments/methods/banks/bancontact)
+- [Bank transfer](/payments/methods/banks/bank-transfer)
+- [Belfius](/payments/methods/banks/belfius)
+- [Dotpay](/payments/methods/banks/dotpay)
+- [EPS](/payments/methods/banks/eps)
+- [Giropay](/payments/methods/banks/giropay)
+- [iDEAL](/payments/methods/banks/ideal)
+- [ING Home'Pay](/payments/methods/banks/ing-home-pay)
+- [KBC](/payments/methods/banks/kbc)
+- [Maestro](/payments/methods/credit-and-debit-cards/maestro)
 + [SEPA Direct Debit](/payments/methods/banks/sepa-direct-debit)
-+ [SOFORT Banking](/payments/methods/banks/sofort-banking)
-+ [Trustly](/payments/methods/banks/trustly)
+- [SOFORT Banking](/payments/methods/banks/sofort-banking)
+- [Trustly](/payments/methods/banks/trustly)
 
 {{< /details >}}
 

--- a/content/payments/integrations/ecommerce-platforms/opencart/faq/supported-payment-methods.md
+++ b/content/payments/integrations/ecommerce-platforms/opencart/faq/supported-payment-methods.md
@@ -10,30 +10,30 @@ aliases:
 ---
 {{< details title="Credit cards" >}}
 
-+ [American Express](/payments/methods/credit-and-debit-cards/american-express)
-+ [Mastercard](/payments/methods/credit-and-debit-cards/mastercard)
-+ [Visa](/payments/methods/credit-and-debit-cards/visa), including [Cartes Bancaires](/payments/methods/credit-and-debit-cards/cartes-bancaires) and [Dankort](/payments/methods/credit-and-debit-cards/dankort)
+- [American Express](/payments/methods/credit-and-debit-cards/american-express)
+- [Mastercard](/payments/methods/credit-and-debit-cards/mastercard)
+- [Visa](/payments/methods/credit-and-debit-cards/visa), including [Cartes Bancaires](/payments/methods/credit-and-debit-cards/cartes-bancaires) and [Dankort](/payments/methods/credit-and-debit-cards/dankort)
 
 {{< /details >}}
 
 {{< details title="Banking methods" >}}
 
-+ [Bancontact](/payments/methods/banks/bancontact)
-+ [Bank transfer](/payments/methods/banks/bank-transfer)
-+ [Belfius](/payments/methods/banks/belfius)
+- [Bancontact](/payments/methods/banks/bancontact)
+- [Bank transfer](/payments/methods/banks/bank-transfer)
+- [Belfius](/payments/methods/banks/belfius)
 + [CBC](/payments/methods/banks/cbc)
-+ [Dotpay](/payments/methods/banks/dotpay)
-+ [EPS](/payments/methods/banks/eps)
-+ [Giropay](/payments/methods/banks/giropay)
-+ [iDEAL](/payments/methods/banks/ideal)
-+ [iDEAL QR](/payments/methods/banks/idealqr)
-+ [ING Home'Pay](/payments/methods/banks/ing-home-pay)
-+ [Maestro](/payments/methods/credit-and-debit-cards/maestro)
-+ [KBC](/payments/methods/banks/kbc)
-+ [Request to Pay](/payments/methods/banks/request-to-pay)
+- [Dotpay](/payments/methods/banks/dotpay)
+- [EPS](/payments/methods/banks/eps)
+- [Giropay](/payments/methods/banks/giropay)
+- [iDEAL](/payments/methods/banks/ideal)
+- [iDEAL QR](/payments/methods/banks/idealqr)
+- [ING Home'Pay](/payments/methods/banks/ing-home-pay)
+- [Maestro](/payments/methods/credit-and-debit-cards/maestro)
+- [KBC](/payments/methods/banks/kbc)
+- [Request to Pay](/payments/methods/banks/request-to-pay)
 + [SEPA Direct Debit](/payments/methods/banks/sepa-direct-debit)
-+ [SOFORT Banking](/payments/methods/banks/sofort-banking)
-+ [Trustly](/payments/methods/banks/trustly)
+- [SOFORT Banking](/payments/methods/banks/sofort-banking)
+- [Trustly](/payments/methods/banks/trustly)
 + [V PAY](/payments/methods/credit-and-debit-cards/vpay)
 
 {{< /details >}}

--- a/content/payments/integrations/ecommerce-platforms/oscommerce/faq/supported-payment-methods.md
+++ b/content/payments/integrations/ecommerce-platforms/oscommerce/faq/supported-payment-methods.md
@@ -10,24 +10,24 @@ aliases:
 ---
 {{< details title="Credit cards" >}}
 
-+ [American Express](/payments/methods/credit-and-debit-cards/american-express)
-+ [Mastercard](/payments/methods/credit-and-debit-cards/mastercard)
-+ [Visa](/payments/methods/credit-and-debit-cards/visa), including [Cartes Bancaires](/payments/methods/credit-and-debit-cards/cartes-bancaires) and [Dankort](/payments/methods/credit-and-debit-cards/dankort)
+- [American Express](/payments/methods/credit-and-debit-cards/american-express)
+- [Mastercard](/payments/methods/credit-and-debit-cards/mastercard)
+- [Visa](/payments/methods/credit-and-debit-cards/visa), including [Cartes Bancaires](/payments/methods/credit-and-debit-cards/cartes-bancaires) and [Dankort](/payments/methods/credit-and-debit-cards/dankort)
 
 {{< /details >}}
 
 {{< details title="Banking methods" >}}
 
-+ [Bancontact](/payments/methods/banks/bancontact)
-+ [Bank transfer](/payments/methods/banks/bank-transfer)
-+ [Dotpay](/payments/methods/banks/dotpay)
-+ [EPS](/payments/methods/banks/eps)
-+ [Giropay](/payments/methods/banks/giropay)
-+ [iDEAL](/payments/methods/banks/ideal)
-+ [KBC](/payments/methods/banks/kbc)
-+ [Maestro](/payments/methods/credit-and-debit-cards/maestro)
+- [Bancontact](/payments/methods/banks/bancontact)
+- [Bank transfer](/payments/methods/banks/bank-transfer)
+- [Dotpay](/payments/methods/banks/dotpay)
+- [EPS](/payments/methods/banks/eps)
+- [Giropay](/payments/methods/banks/giropay)
+- [iDEAL](/payments/methods/banks/ideal)
+- [KBC](/payments/methods/banks/kbc)
+- [Maestro](/payments/methods/credit-and-debit-cards/maestro)
 + [SEPA Direct Debit](/payments/methods/banks/sepa-direct-debit)
-+ [SOFORT Banking](/payments/methods/banks/sofort-banking)
+- [SOFORT Banking](/payments/methods/banks/sofort-banking)
 + [V PAY](/payments/methods/credit-and-debit-cards/vpay)
 
 {{< /details >}}

--- a/content/payments/integrations/ecommerce-platforms/prestashop-1-6/faq/supported-payment-methods.md
+++ b/content/payments/integrations/ecommerce-platforms/prestashop-1-6/faq/supported-payment-methods.md
@@ -10,28 +10,28 @@ aliases:
 ---
 {{< details title="Credit cards" >}}
 
-+ [American Express](/payments/methods/credit-and-debit-cards/american-express)
-+ [Mastercard](/payments/methods/credit-and-debit-cards/mastercard)
-+ [Visa](/payments/methods/credit-and-debit-cards/visa), including [Cartes Bancaires](/payments/methods/credit-and-debit-cards/cartes-bancaires) and [Dankort](/payments/methods/credit-and-debit-cards/dankort)
+- [American Express](/payments/methods/credit-and-debit-cards/american-express)
+- [Mastercard](/payments/methods/credit-and-debit-cards/mastercard)
+- [Visa](/payments/methods/credit-and-debit-cards/visa), including [Cartes Bancaires](/payments/methods/credit-and-debit-cards/cartes-bancaires) and [Dankort](/payments/methods/credit-and-debit-cards/dankort)
 
 {{< /details >}}
 
 {{< details title="Banking methods" >}}
 
-+ [Bancontact](/payments/methods/banks/bancontact)
-+ [Bank transfer](/payments/methods/banks/bank-transfer)
-+ [Belfius](/payments/methods/banks/belfius)
+- [Bancontact](/payments/methods/banks/bancontact)
+- [Bank transfer](/payments/methods/banks/bank-transfer)
+- [Belfius](/payments/methods/banks/belfius)
 + [CBC](/payments/methods/banks/cbc)
-+ [Dotpay](/payments/methods/banks/dotpay)
-+ [EPS](/payments/methods/banks/eps)
-+ [Giropay](/payments/methods/banks/giropay)
-+ [iDEAL](/payments/methods/banks/ideal)
-+ [ING Home'Pay](/payments/methods/banks/ing-home-pay)
-+ [KBC](/payments/methods/banks/kbc)
-+ [Maestro](/payments/methods/credit-and-debit-cards/maestro)
-+ [Request to Pay](/payments/methods/banks/request-to-pay)
+- [Dotpay](/payments/methods/banks/dotpay)
+- [EPS](/payments/methods/banks/eps)
+- [Giropay](/payments/methods/banks/giropay)
+- [iDEAL](/payments/methods/banks/ideal)
+- [ING Home'Pay](/payments/methods/banks/ing-home-pay)
+- [KBC](/payments/methods/banks/kbc)
+- [Maestro](/payments/methods/credit-and-debit-cards/maestro)
+- [Request to Pay](/payments/methods/banks/request-to-pay)
 + [SEPA Direct Debit](/payments/methods/banks/sepa-direct-debit)
-+ [SOFORT Banking](/payments/methods/banks/sofort-banking)
+- [SOFORT Banking](/payments/methods/banks/sofort-banking)
 + [V PAY](/payments/methods/credit-and-debit-cards/vpay)
 
 {{< /details >}}

--- a/content/payments/integrations/ecommerce-platforms/prestashop-1-7/faq/supported-payment-methods.md
+++ b/content/payments/integrations/ecommerce-platforms/prestashop-1-7/faq/supported-payment-methods.md
@@ -10,30 +10,30 @@ aliases:
 ---
 {{< details title="Credit cards" >}}
 
-+ [American Express](/payments/methods/credit-and-debit-cards/american-express)
-+ [Mastercard](/payments/methods/credit-and-debit-cards/mastercard)
-+ [Visa](/payments/methods/credit-and-debit-cards/visa), including [Cartes Bancaires](/payments/methods/credit-and-debit-cards/cartes-bancaires) and [Dankort](/payments/methods/credit-and-debit-cards/dankort)
+- [American Express](/payments/methods/credit-and-debit-cards/american-express)
+- [Mastercard](/payments/methods/credit-and-debit-cards/mastercard)
+- [Visa](/payments/methods/credit-and-debit-cards/visa), including [Cartes Bancaires](/payments/methods/credit-and-debit-cards/cartes-bancaires) and [Dankort](/payments/methods/credit-and-debit-cards/dankort)
 
 {{< /details >}}
 
 {{< details title="Banking methods" >}}
 
-+ [Bancontact](/payments/methods/banks/bancontact)
-+ [Bank transfer](/payments/methods/banks/bank-transfer)
-+ [Belfius](/payments/methods/banks/belfius)
+- [Bancontact](/payments/methods/banks/bancontact)
+- [Bank transfer](/payments/methods/banks/bank-transfer)
+- [Belfius](/payments/methods/banks/belfius)
 + [CBC](/payments/methods/banks/cbc)
-+ [Dotpay](/payments/methods/banks/dotpay)
-+ [EPS](/payments/methods/banks/eps)
-+ [Giropay](/payments/methods/banks/giropay)
-+ [iDEAL](/payments/methods/banks/ideal)
-+ [iDEAL QR](/payments/methods/banks/idealqr)
-+ [ING Home'Pay](/payments/methods/banks/ing-home-pay)
-+ [KBC](/payments/methods/banks/kbc)
-+ [Maestro](/payments/methods/credit-and-debit-cards/maestro)
-+ [Request to Pay](/payments/methods/banks/request-to-pay)
+- [Dotpay](/payments/methods/banks/dotpay)
+- [EPS](/payments/methods/banks/eps)
+- [Giropay](/payments/methods/banks/giropay)
+- [iDEAL](/payments/methods/banks/ideal)
+- [iDEAL QR](/payments/methods/banks/idealqr)
+- [ING Home'Pay](/payments/methods/banks/ing-home-pay)
+- [KBC](/payments/methods/banks/kbc)
+- [Maestro](/payments/methods/credit-and-debit-cards/maestro)
+- [Request to Pay](/payments/methods/banks/request-to-pay)
 + [SEPA Direct Debit](/payments/methods/banks/sepa-direct-debit)
-+ [SOFORT Banking](/payments/methods/banks/sofort-banking)
-+ [Trustly](/payments/methods/banks/trustly)
+- [SOFORT Banking](/payments/methods/banks/sofort-banking)
+- [Trustly](/payments/methods/banks/trustly)
 + [TrustPay](/payments/methods/banks/trustpay)
 + [V PAY](/payments/methods/credit-and-debit-cards/vpay)
 

--- a/content/payments/integrations/ecommerce-platforms/shopify/faq/supported-payment-methods.md
+++ b/content/payments/integrations/ecommerce-platforms/shopify/faq/supported-payment-methods.md
@@ -9,41 +9,40 @@ aliases:
 ---
 {{< details title="Credit cards" >}}
 
-+ [American Express](/payments/methods/credit-and-debit-cards/american-express)
-+ [Mastercard](/payments/methods/credit-and-debit-cards/mastercard)
-+ [Visa](/payments/methods/credit-and-debit-cards/visa), including [Cartes Bancaires](/payments/methods/credit-and-debit-cards/cartes-bancaires) and [Dankort](/payments/methods/credit-and-debit-cards/dankort)
+- [American Express](/payments/methods/credit-and-debit-cards/american-express)
+- [Mastercard](/payments/methods/credit-and-debit-cards/mastercard)
+- [Visa](/payments/methods/credit-and-debit-cards/visa), including [Cartes Bancaires](/payments/methods/credit-and-debit-cards/cartes-bancaires) and [Dankort](/payments/methods/credit-and-debit-cards/dankort)
 
 {{< /details >}}
 
 {{< details title="Banking methods" >}}
 
-+ [Bancontact](/payments/methods/banks/bancontact)
-+ [Bank transfer](/payments/methods/banks/bank-transfer)
-+ [Belfius](/payments/methods/banks/belfius)
-+ [Dotpay](/payments/methods/banks/dotpay)
-+ [EPS](/payments/methods/banks/eps)
-+ [Giropay](/payments/methods/banks/giropay)
-+ [iDEAL](/payments/methods/banks/ideal)
-+ [iDEAL QR](/payments/methods/banks/idealqr)
-+ [ING Home'Pay](/payments/methods/banks/ing-home-pay)
-+ [KBC](/payments/methods/banks/kbc)
-+ [Maestro](/payments/methods/credit-and-debit-cards/maestro)
-+ [Request to Pay](/payments/methods/banks/request-to-pay)
-+ [SEPA Direct Debit](/payments/methods/banks/sepa-direct-debit)
-+ [SOFORT Banking](/payments/methods/banks/sofort-banking)
-+ [Trustly](/payments/methods/banks/trustly)
+- [Bancontact](/payments/methods/banks/bancontact)
+- [Bank transfer](/payments/methods/banks/bank-transfer)
+- [Belfius](/payments/methods/banks/belfius)
+- [Dotpay](/payments/methods/banks/dotpay)
+- [EPS](/payments/methods/banks/eps)
+- [Giropay](/payments/methods/banks/giropay)
+- [iDEAL](/payments/methods/banks/ideal)
+- [iDEAL QR](/payments/methods/banks/idealqr)
+- [ING Home'Pay](/payments/methods/banks/ing-home-pay)
+- [KBC](/payments/methods/banks/kbc)
+- [Maestro](/payments/methods/credit-and-debit-cards/maestro)
+- [Request to Pay](/payments/methods/banks/request-to-pay)
+- [SOFORT Banking](/payments/methods/banks/sofort-banking)
+- [Trustly](/payments/methods/banks/trustly)
 
 {{< /details >}}
 
 {{< details title="Wallets" >}}
 
-+ [Alipay](/payments/methods/wallet/alipay)
-+ [PayPal](/payments/methods/wallet/paypal)
+- [Alipay](/payments/methods/wallet/alipay)
+- [PayPal](/payments/methods/wallet/paypal)
 
 {{< /details >}}
 
 {{< details title="Prepaid cards" >}}
 
-+ [Paysafecard](/payments/methods/prepaid-cards/paysafecard)
+[Paysafecard](/payments/methods/prepaid-cards/paysafecard)
 
 {{< /details >}}

--- a/content/payments/integrations/ecommerce-platforms/shopware5/faq/supported-payment-methods.md
+++ b/content/payments/integrations/ecommerce-platforms/shopware5/faq/supported-payment-methods.md
@@ -10,30 +10,30 @@ aliases:
 ---
 {{< details title="Credit cards" >}}
 
-+ [American Express](/payments/methods/credit-and-debit-cards/american-express)
-+ [Mastercard](/payments/methods/credit-and-debit-cards/mastercard)
-+ [Visa](/payments/methods/credit-and-debit-cards/visa), including [Cartes Bancaires](/payments/methods/credit-and-debit-cards/cartes-bancaires) & [Dankort](/payments/methods/credit-and-debit-cards/dankort)
+- [American Express](/payments/methods/credit-and-debit-cards/american-express)
+- [Mastercard](/payments/methods/credit-and-debit-cards/mastercard)
+- [Visa](/payments/methods/credit-and-debit-cards/visa), including [Cartes Bancaires](/payments/methods/credit-and-debit-cards/cartes-bancaires) & [Dankort](/payments/methods/credit-and-debit-cards/dankort)
 
 {{< /details >}}
 
 {{< details title="Banking methods" >}}
 
-+ [Bancontact](/payments/methods/banks/bancontact)
-+ [Bank transfer](/payments/methods/banks/bank-transfer)
-+ [Belfius](/payments/methods/banks/belfius)
+- [Bancontact](/payments/methods/banks/bancontact)
+- [Bank transfer](/payments/methods/banks/bank-transfer)
+- [Belfius](/payments/methods/banks/belfius)
 + [CBC](/payments/methods/banks/cbc)
-+ [Dotpay](/payments/methods/banks/dotpay)
-+ [EPS](/payments/methods/banks/eps)
-+ [Giropay](/payments/methods/banks/giropay)
-+ [iDEAL](/payments/methods/banks/ideal)
-+ [iDEAL QR](/payments/methods/banks/idealqr)
-+ [ING Home'Pay](/payments/methods/banks/ing-home-pay)
-+ [KBC](/payments/methods/banks/kbc)
-+ [Maestro](/payments/methods/credit-and-debit-cards/maestro)
-+ [Request to Pay](/payments/methods/banks/request-to-pay)
+- [Dotpay](/payments/methods/banks/dotpay)
+- [EPS](/payments/methods/banks/eps)
+- [Giropay](/payments/methods/banks/giropay)
+- [iDEAL](/payments/methods/banks/ideal)
+- [iDEAL QR](/payments/methods/banks/idealqr)
+- [ING Home'Pay](/payments/methods/banks/ing-home-pay)
+- [KBC](/payments/methods/banks/kbc)
+- [Maestro](/payments/methods/credit-and-debit-cards/maestro)
+- [Request to Pay](/payments/methods/banks/request-to-pay)
 + [SEPA Direct Debit](/payments/methods/banks/sepa-direct-debit)
-+ [SOFORT Banking](/payments/methods/banks/sofort-banking)
-+ [Trustly](/payments/methods/banks/trustly)
+- [SOFORT Banking](/payments/methods/banks/sofort-banking)
+- [Trustly](/payments/methods/banks/trustly)
 + [TrustPay](/payments/methods/banks/trustpay)
 + [V PAY](/payments/methods/credit-and-debit-cards/vpay)
 

--- a/content/payments/integrations/ecommerce-platforms/shopware6/faq/supported-payment-methods.md
+++ b/content/payments/integrations/ecommerce-platforms/shopware6/faq/supported-payment-methods.md
@@ -10,29 +10,29 @@ aliases:
 ---
 {{< details title="Credit cards" >}}
 
-+ [American Express](/payments/methods/credit-and-debit-cards/american-express)
-+ [Mastercard](/payments/methods/credit-and-debit-cards/mastercard)
-+ [Visa](/payments/methods/credit-and-debit-cards/visa), including [Cartes Bancaires](/payments/methods/credit-and-debit-cards/cartes-bancaires) & [Dankort](/payments/methods/credit-and-debit-cards/dankort)
+- [American Express](/payments/methods/credit-and-debit-cards/american-express)
+- [Mastercard](/payments/methods/credit-and-debit-cards/mastercard)
+- [Visa](/payments/methods/credit-and-debit-cards/visa), including [Cartes Bancaires](/payments/methods/credit-and-debit-cards/cartes-bancaires) & [Dankort](/payments/methods/credit-and-debit-cards/dankort)
 
 {{< /details >}}
 
 {{< details title="Banking methods" >}}
 
-+ [Bancontact](/payments/methods/banks/bancontact)
-+ [Bank transfer](/payments/methods/banks/bank-transfer)
-+ [Belfius](/payments/methods/banks/belfius)
-+ [Dotpay](/payments/methods/banks/dotpay)
-+ [EPS](/payments/methods/banks/eps)
-+ [Giropay](/payments/methods/banks/giropay)
-+ [iDEAL](/payments/methods/banks/ideal)
-+ [ING Home'Pay](/payments/methods/banks/ing-home-pay)
+- [Bancontact](/payments/methods/banks/bancontact)
+- [Bank transfer](/payments/methods/banks/bank-transfer)
+- [Belfius](/payments/methods/banks/belfius)
+- [Dotpay](/payments/methods/banks/dotpay)
+- [EPS](/payments/methods/banks/eps)
+- [Giropay](/payments/methods/banks/giropay)
+- [iDEAL](/payments/methods/banks/ideal)
+- [ING Home'Pay](/payments/methods/banks/ing-home-pay)
 + [CBC](/payments/methods/banks/cbc)
-+ [KBC](/payments/methods/banks/kbc)
-+ [Maestro](/payments/methods/credit-and-debit-cards/maestro)
-+ [Request to Pay](/payments/methods/banks/request-to-pay)
+- [KBC](/payments/methods/banks/kbc)
+- [Maestro](/payments/methods/credit-and-debit-cards/maestro)
+- [Request to Pay](/payments/methods/banks/request-to-pay)
 + [SEPA Direct Debit](/payments/methods/banks/sepa-direct-debit)
-+ [SOFORT Banking](/payments/methods/banks/sofort-banking)
-+ [Trustly](/payments/methods/banks/trustly)
+- [SOFORT Banking](/payments/methods/banks/sofort-banking)
+- [Trustly](/payments/methods/banks/trustly)
 + [TrustPay](/payments/methods/banks/trustpay)
 + [V PAY](/payments/methods/credit-and-debit-cards/vpay)
 

--- a/content/payments/integrations/ecommerce-platforms/virtuemart/faq/supported-payment-methods.md
+++ b/content/payments/integrations/ecommerce-platforms/virtuemart/faq/supported-payment-methods.md
@@ -10,28 +10,28 @@ aliases:
 ---
 {{< details title="Credit cards" >}}
 
-+ [American Express](/payments/methods/credit-and-debit-cards/american-express)
-+ [Mastercard](/payments/methods/credit-and-debit-cards/mastercard)
-+ [Visa](/payments/methods/credit-and-debit-cards/visa), including [Cartes Bancaires](/payments/methods/credit-and-debit-cards/cartes-bancaires) and [Dankort](/payments/methods/credit-and-debit-cards/dankort)
+- [American Express](/payments/methods/credit-and-debit-cards/american-express)
+- [Mastercard](/payments/methods/credit-and-debit-cards/mastercard)
+- [Visa](/payments/methods/credit-and-debit-cards/visa), including [Cartes Bancaires](/payments/methods/credit-and-debit-cards/cartes-bancaires) and [Dankort](/payments/methods/credit-and-debit-cards/dankort)
 
 {{< /details >}}
 
 {{< details title="Banking methods" >}}
 
-+ [Bancontact](/payments/methods/banks/bancontact)
-+ [Bank transfer](/payments/methods/banks/bank-transfer)
-+ [Belfius](/payments/methods/banks/belfius)
-+ [Dotpay](/payments/methods/banks/dotpay)
-+ [EPS](/payments/methods/banks/eps)
-+ [Giropay](/payments/methods/banks/giropay)
-+ [iDEAL](/payments/methods/banks/ideal)
-+ [iDEAL QR](/payments/methods/banks/idealqr)
-+ [ING Home'Pay](/payments/methods/banks/ing-home-pay)
-+ [KBC](/payments/methods/banks/kbc)
-+ [Maestro](/payments/methods/credit-and-debit-cards/maestro)
+- [Bancontact](/payments/methods/banks/bancontact)
+- [Bank transfer](/payments/methods/banks/bank-transfer)
+- [Belfius](/payments/methods/banks/belfius)
+- [Dotpay](/payments/methods/banks/dotpay)
+- [EPS](/payments/methods/banks/eps)
+- [Giropay](/payments/methods/banks/giropay)
+- [iDEAL](/payments/methods/banks/ideal)
+- [iDEAL QR](/payments/methods/banks/idealqr)
+- [ING Home'Pay](/payments/methods/banks/ing-home-pay)
+- [KBC](/payments/methods/banks/kbc)
+- [Maestro](/payments/methods/credit-and-debit-cards/maestro)
 + [SEPA Direct Debit](/payments/methods/banks/sepa-direct-debit)
-+ [SOFORT Banking](/payments/methods/banks/sofort-banking)
-+ [Trustly](/payments/methods/banks/trustly)
+- [SOFORT Banking](/payments/methods/banks/sofort-banking)
+- [Trustly](/payments/methods/banks/trustly)
 + [TrustPay](/payments/methods/banks/trustpay)
 + [V PAY](/payments/methods/credit-and-debit-cards/vpay)
 

--- a/content/payments/integrations/ecommerce-platforms/woocommerce/faq/supported-payment-methods.md
+++ b/content/payments/integrations/ecommerce-platforms/woocommerce/faq/supported-payment-methods.md
@@ -10,30 +10,30 @@ aliases:
 ---
 {{< details title="Credit cards" >}}
 
-+ [American Express](/payments/methods/credit-and-debit-cards/american-express)
-+ [Mastercard](/payments/methods/credit-and-debit-cards/mastercard)
-+ [Visa](/payments/methods/credit-and-debit-cards/visa), including [Cartes Bancaires](/payments/methods/credit-and-debit-cards/cartes-bancaires) and [Dankort](/payments/methods/credit-and-debit-cards/dankort)
+- [American Express](/payments/methods/credit-and-debit-cards/american-express)
+- [Mastercard](/payments/methods/credit-and-debit-cards/mastercard)
+- [Visa](/payments/methods/credit-and-debit-cards/visa), including [Cartes Bancaires](/payments/methods/credit-and-debit-cards/cartes-bancaires) and [Dankort](/payments/methods/credit-and-debit-cards/dankort)
 
 {{< /details >}}
 
 {{< details title="Banking methods" >}}
 
-+ [Bancontact](/payments/methods/banks/bancontact)
-+ [Bank transfer](/payments/methods/banks/bank-transfer)
-+ [Belfius](/payments/methods/banks/belfius)
+- [Bancontact](/payments/methods/banks/bancontact)
+- [Bank transfer](/payments/methods/banks/bank-transfer)
+- [Belfius](/payments/methods/banks/belfius)
 + [CBC](/payments/methods/banks/cbc)
-+ [Dotpay](/payments/methods/banks/dotpay)
-+ [EPS](/payments/methods/banks/eps)
-+ [Giropay](/payments/methods/banks/giropay)
-+ [iDEAL](/payments/methods/banks/ideal)
-+ [iDEAL QR](/payments/methods/banks/idealqr)
-+ [ING Home'Pay](/payments/methods/banks/ing-home-pay)
-+ [KBC](/payments/methods/banks/kbc)
-+ [Maestro](/payments/methods/credit-and-debit-cards/maestro)
-+ [Request to Pay](/payments/methods/banks/request-to-pay)
+- [Dotpay](/payments/methods/banks/dotpay)
+- [EPS](/payments/methods/banks/eps)
+- [Giropay](/payments/methods/banks/giropay)
+- [iDEAL](/payments/methods/banks/ideal)
+- [iDEAL QR](/payments/methods/banks/idealqr)
+- [ING Home'Pay](/payments/methods/banks/ing-home-pay)
+- [KBC](/payments/methods/banks/kbc)
+- [Maestro](/payments/methods/credit-and-debit-cards/maestro)
+- [Request to Pay](/payments/methods/banks/request-to-pay)
 + [SEPA Direct Debit](/payments/methods/banks/sepa-direct-debit)
-+ [SOFORT Banking](/payments/methods/banks/sofort-banking)
-+ [Trustly](/payments/methods/banks/trustly)
+- [SOFORT Banking](/payments/methods/banks/sofort-banking)
+- [Trustly](/payments/methods/banks/trustly)
 + [V PAY](/payments/methods/credit-and-debit-cards/vpay)
 
 {{< /details >}}

--- a/content/payments/integrations/ecommerce-platforms/x-cart/faq/supported-payment-methods.md
+++ b/content/payments/integrations/ecommerce-platforms/x-cart/faq/supported-payment-methods.md
@@ -10,28 +10,28 @@ aliases:
 ---
 {{< details title="Credit cards" >}}
 
-+ [American Express](/payments/methods/credit-and-debit-cards/american-express)
-+ [Mastercard](/payments/methods/credit-and-debit-cards/mastercard)
-+ [Visa](/payments/methods/credit-and-debit-cards/visa), including [Cartes Bancaires](/payments/methods/credit-and-debit-cards/cartes-bancaires) and [Dankort](/payments/methods/credit-and-debit-cards/dankort)
+- [American Express](/payments/methods/credit-and-debit-cards/american-express)
+- [Mastercard](/payments/methods/credit-and-debit-cards/mastercard)
+- [Visa](/payments/methods/credit-and-debit-cards/visa), including [Cartes Bancaires](/payments/methods/credit-and-debit-cards/cartes-bancaires) and [Dankort](/payments/methods/credit-and-debit-cards/dankort)
 
 {{< /details >}}
 
 {{< details title="Banking methods" >}}
 
-+ [Bancontact](/payments/methods/banks/bancontact)
-+ [Bank transfer](/payments/methods/banks/bank-transfer)
-+ [Belfius](/payments/methods/banks/belfius)
-+ [Dotpay](/payments/methods/banks/dotpay)
-+ [EPS](/payments/methods/banks/eps)
-+ [Giropay](/payments/methods/banks/giropay)
-+ [iDEAL](/payments/methods/banks/ideal)
-+ [iDEAL QR](/payments/methods/banks/idealqr)
-+ [ING Home'Pay](/payments/methods/banks/ing-home-pay)
-+ [KBC](/payments/methods/banks/kbc)
-+ [Maestro](/payments/methods/credit-and-debit-cards/maestro)
+- [Bancontact](/payments/methods/banks/bancontact)
+- [Bank transfer](/payments/methods/banks/bank-transfer)
+- [Belfius](/payments/methods/banks/belfius)
+- [Dotpay](/payments/methods/banks/dotpay)
+- [EPS](/payments/methods/banks/eps)
+- [Giropay](/payments/methods/banks/giropay)
+- [iDEAL](/payments/methods/banks/ideal)
+- [iDEAL QR](/payments/methods/banks/idealqr)
+- [ING Home'Pay](/payments/methods/banks/ing-home-pay)
+- [KBC](/payments/methods/banks/kbc)
+- [Maestro](/payments/methods/credit-and-debit-cards/maestro)
 + [SEPA Direct Debit](/payments/methods/banks/sepa-direct-debit)
-+ [SOFORT Banking](/payments/methods/banks/sofort-banking)
-+ [Trustly](/payments/methods/banks/trustly)
+- [SOFORT Banking](/payments/methods/banks/sofort-banking)
+- [Trustly](/payments/methods/banks/trustly)
 + [TrustPay](/payments/methods/banks/trustpay)
 + [V PAY](/payments/methods/credit-and-debit-cards/vpay)
 

--- a/content/payments/integrations/ecommerce-platforms/zencart/faq/supported-payment-methods.md
+++ b/content/payments/integrations/ecommerce-platforms/zencart/faq/supported-payment-methods.md
@@ -10,28 +10,28 @@ aliases:
 ---
 {{< details title="Credit cards" >}}
 
-+ [American Express](/payments/methods/credit-and-debit-cards/american-express)
-+ [Mastercard](/payments/methods/credit-and-debit-cards/mastercard)
-+ [Visa](/payments/methods/credit-and-debit-cards/visa), including [Cartes Bancaires](/payments/methods/credit-and-debit-cards/cartes-bancaires) and [Dankort](/payments/methods/credit-and-debit-cards/dankort)
+- [American Express](/payments/methods/credit-and-debit-cards/american-express)
+- [Mastercard](/payments/methods/credit-and-debit-cards/mastercard)
+- [Visa](/payments/methods/credit-and-debit-cards/visa), including [Cartes Bancaires](/payments/methods/credit-and-debit-cards/cartes-bancaires) and [Dankort](/payments/methods/credit-and-debit-cards/dankort)
 
 {{< /details >}}
 
 {{< details title="Banking methods" >}}
 
-+ [Bancontact](/payments/methods/banks/bancontact)
-+ [Bank transfer](/payments/methods/banks/bank-transfer)
-+ [Belfius](/payments/methods/banks/belfius)
-+ [Dotpay](/payments/methods/banks/dotpay)
-+ [EPS](/payments/methods/banks/eps)
-+ [Giropay](/payments/methods/banks/giropay)
-+ [iDEAL](/payments/methods/banks/ideal)
-+ [ING Home'Pay](/payments/methods/banks/ing-home-pay)
-+ [KBC](/payments/methods/banks/kbc)
-+ [Maestro](/payments/methods/credit-and-debit-cards/maestro)
-+ [Request to Pay](/payments/methods/banks/request-to-pay)
+- [Bancontact](/payments/methods/banks/bancontact)
+- [Bank transfer](/payments/methods/banks/bank-transfer)
+- [Belfius](/payments/methods/banks/belfius)
+- [Dotpay](/payments/methods/banks/dotpay)
+- [EPS](/payments/methods/banks/eps)
+- [Giropay](/payments/methods/banks/giropay)
+- [iDEAL](/payments/methods/banks/ideal)
+- [ING Home'Pay](/payments/methods/banks/ing-home-pay)
+- [KBC](/payments/methods/banks/kbc)
+- [Maestro](/payments/methods/credit-and-debit-cards/maestro)
+- [Request to Pay](/payments/methods/banks/request-to-pay)
 + [SEPA Direct Debit](/payments/methods/banks/sepa-direct-debit)
-+ [SOFORT Banking](/payments/methods/banks/sofort-banking)
-+ [Trustly](/payments/methods/banks/trustly)
+- [SOFORT Banking](/payments/methods/banks/sofort-banking)
+- [Trustly](/payments/methods/banks/trustly)
 + [V PAY](/payments/methods/credit-and-debit-cards/vpay)
 
 {{< /details >}}

--- a/content/payments/integrations/ecommerce-platforms/zilvercms/faq/supported-payment-methods.md
+++ b/content/payments/integrations/ecommerce-platforms/zilvercms/faq/supported-payment-methods.md
@@ -7,26 +7,26 @@ read_more: "."
 
 {{< details title="Credit cards" >}}
 
-+ [American Express](/payments/methods/credit-and-debit-cards/american-express)
-+ [Mastercard](/payments/methods/credit-and-debit-cards/mastercard)
-+ [Visa](/payments/methods/credit-and-debit-cards/visa), including [Cartes Bancaires](/payments/methods/credit-and-debit-cards/cartes-bancaires) and [Dankort](/payments/methods/credit-and-debit-cards/dankort)
+- [American Express](/payments/methods/credit-and-debit-cards/american-express)
+- [Mastercard](/payments/methods/credit-and-debit-cards/mastercard)
+- [Visa](/payments/methods/credit-and-debit-cards/visa), including [Cartes Bancaires](/payments/methods/credit-and-debit-cards/cartes-bancaires) and [Dankort](/payments/methods/credit-and-debit-cards/dankort)
 
 {{< /details >}}
 
 {{< details title="Banking methods" >}}
 
-+ [Bancontact](/payments/methods/banks/bancontact)
-+ [Bank transfer](/payments/methods/banks/bank-transfer)
-+ [Belfius](/payments/methods/banks/belfius)
-+ [Dotpay](/payments/methods/banks/dotpay)
-+ [EPS](/payments/methods/banks/eps)
-+ [Giropay](/payments/methods/banks/giropay) 
-+ [iDEAL](/payments/methods/banks/ideal)
-+ [iDEAL QR](/payments/methods/banks/idealqr)
-+ [ING Home'Pay](/payments/methods/banks/ing-home-pay)
-+ [KBC](/payments/methods/banks/kbc)
-+ [Maestro](/payments/methods/credit-and-debit-cards/maestro)
-+ [Request to Pay](/payments/methods/banks/request-to-pay)
+- [Bancontact](/payments/methods/banks/bancontact)
+- [Bank transfer](/payments/methods/banks/bank-transfer)
+- [Belfius](/payments/methods/banks/belfius)
+- [Dotpay](/payments/methods/banks/dotpay)
+- [EPS](/payments/methods/banks/eps)
+- [Giropay](/payments/methods/banks/giropay) 
+- [iDEAL](/payments/methods/banks/ideal)
+- [iDEAL QR](/payments/methods/banks/idealqr)
+- [ING Home'Pay](/payments/methods/banks/ing-home-pay)
+- [KBC](/payments/methods/banks/kbc)
+- [Maestro](/payments/methods/credit-and-debit-cards/maestro)
+- [Request to Pay](/payments/methods/banks/request-to-pay)
 + [SEPA Direct Debit](/payments/methods/banks/sepa-direct-debit)
 
 {{< /details >}}


### PR DESCRIPTION
Do the changes meet MultiSafepay Docs' Definition of Done?
- Style guide, tone of voice, and naming conventions
- Tested
- Reviewed on mobile, tablet and desktop screens
- Notified stakeholders
- Pass GitHub Actions
