### PR TITLE
Make <details> elements anchor-linkable

### DIFF
--- a/layouts/shortcodes/details.html
+++ b/layouts/shortcodes/details.html
@@ -1,5 +1,5 @@
 <div>
-	<details>
+	<details id="details-{{ .Get "title" }}">
 		<summary>
 			{{ .Get "title" }}
 		</summary>


### PR DESCRIPTION
To link to a <details> element with title="Foo":

[Text with hyperlink](#details-foo)

Note how the title is converted to lowercase.

Do the changes meet MultiSafepay Docs' Definition of Done?
- Style guide, tone of voice, and naming conventions
- Tested
- Reviewed on mobile, tablet and desktop screens
- Notified stakeholders
- Pass GitHub Actions
