### PR TITLE
Make <details> elements anchor-linkable

### DIFF
--- a/layouts/shortcodes/details.html
+++ b/layouts/shortcodes/details.html
@@ -1,5 +1,5 @@
 <div>
-	<details id="details-{{ .Get "title" | lower }}">
+	<details id="details-{{ replace (.Get "title" | lower) " " "-" }}">
 		<summary>
 			{{ .Get "title" }}
 		</summary>


### PR DESCRIPTION
- Replace whitespaces by dashes to support markdown links
(Markdown links don't allow for whitespaces)

{{< details title="This is a Title 123" >}}

is now compiled into:

<summary id="details-this-is-a-title-123">This is a Title 123</summary>

Do the changes meet MultiSafepay Docs' Definition of Done?
- Style guide, tone of voice, and naming conventions
- Tested
- Reviewed on mobile, tablet and desktop screens
- Notified stakeholders
- Pass GitHub Actions
