### PR TITLE
DOCS-2912: Fix broken download and changelog links in PrestaShop 1.6

### DIFF
--- a/content/integration/ready-made/prestashop-1-6/_index.md
+++ b/content/integration/ready-made/prestashop-1-6/_index.md
@@ -1,8 +1,8 @@
 ---
 title : "MultiSafepay plugin for PrestaShop 1.6"
-download_url : "/payments/integrations/ready-made/prestashop-1-6/releases/Plugin_PrestaShop1.6_3.7.0.zip"
-changelog_url : "/payments/integrations/ready-made/prestashop-1-6/changelog/"
-changelog: https://docs.multisafepay.com/payments/integrations/ready-made/prestashop-1-6/changelog/
+download_url : "/integration/ready-made/prestashop-1-6/releases/Plugin_PrestaShop1.6_3.7.0.zip"
+changelog_url : "/integration/ready-made/prestashop-1-6/changelog/"
+changelog: https://docs.multisafepay.com/integration/ready-made/prestashop-1-6/changelog/
 faq: "."
 meta_title: "PrestaShop 1.6 plugin - MultiSafepay Docs"
 logo: "/logo/Plugins/PrestaShop.svg"


### PR DESCRIPTION
It seems this was fixed a couple of days ago in #1874.
Not sure why the links are broken again, perhaps the directory structure changed since then.

It has been reported to me by a user who requires to download the module.

