### PR TITLE
Release of 4.11.0 WooCommerce plugin

### DIFF
--- a/content/integration/ready-made/woocommerce/_index.md
+++ b/content/integration/ready-made/woocommerce/_index.md
@@ -1,7 +1,7 @@
 ---
 title : "MultiSafepay plugin for WooCommerce"
 github_url : "https://github.com/MultiSafepay/WooCommerce"
-download_url : "https://github.com/MultiSafepay/WooCommerce/releases/download/4.10.0/Plugin_WooCommerce_4.10.0.zip"
+download_url : "https://github.com/MultiSafepay/WooCommerce/releases/download/4.11.0/Plugin_WooCommerce_4.11.0.zip"
 changelog_url : "."
 faq: "."
 repo_url : "MultiSafepay/WooCommerce"


### PR DESCRIPTION
This PR change the download link according with the release of 4.11.0 WooCommerce plugin.