### PR TITLE
DOCS-2931: FAQ item about Payment Component within WooCommerce

### DIFF
--- a/content/integration/ready-made/woocommerce/faq/activating-payment-component.md
+++ b/content/integration/ready-made/woocommerce/faq/activating-payment-component.md
@@ -12,7 +12,7 @@ The MultiSafepay WooCommerce plugin supports [Payment Components](/payment-compo
 - Encrypt customer payment details for secure processing.
 - Shift responsibility for [PCI DSS compliance](/glossaries/multisafepay-glossary/#payment-card-industry-data-security-standard-pci-dss) to MultiSafepay.
 
-If you're new to accepting credit card payments, email applications to activate them your account manager at <sales@multisafepay.com>
+If you're new to accepting credit card payments, email a request to activate them to <sales@multisafepay.com>
 
 ## Activating the Payment Component
 

--- a/content/integration/ready-made/woocommerce/faq/activating-payment-component.md
+++ b/content/integration/ready-made/woocommerce/faq/activating-payment-component.md
@@ -19,7 +19,7 @@ If you're new to accepting credit card payments, email a request to activate the
 To activate the Payment Component in your Wordpress - WooCommerce [backend](/glossaries/multisafepay-glossary/#backend), follow these steps:
 
 1. Sign in to your Wordpress backend.
-2. Go to **WooCommerce** > **MultiSafepay Settings** > **Payment Methods** > **Credit Card**, and then click **Manage**.
+2. Go to **WooCommerce** > **MultiSafepay settings** > **Payment methods** > **Credit card**, and then click **Manage**.
 3. Click in the **Payment Components** checkbox to enable this feature.
 4. Click **Save changes**.
 

--- a/content/integration/ready-made/woocommerce/faq/activating-payment-component.md
+++ b/content/integration/ready-made/woocommerce/faq/activating-payment-component.md
@@ -1,0 +1,28 @@
+---
+title : "Activating Payment Components"
+meta_title: "WooCommerce plugin - Activating Payment Components - MultiSafepay Docs"
+layout: "faqdetail"
+read_more: "."
+url: '/woo-commerce/payment-components/'
+---
+
+The MultiSafepay WooCommerce plugin supports [Payment Components](/payment-components/), which:
+
+- Provide a seamless checkout experience to increase [conversion](/glossaries/multisafepay-glossary/#conversion-rate).
+- Encrypt customer payment details for secure processing.
+- Shift responsibility for [PCI DSS compliance](/glossaries/multisafepay-glossary/#payment-card-industry-data-security-standard-pci-dss) to MultiSafepay.
+
+If you're new to accepting credit card payments, email applications to activate them your account manager at <sales@multisafepay.com>
+
+## Activating the Payment Component
+
+To activate the Payment Component in your Wordpress - WooCommerce [backend](/glossaries/multisafepay-glossary/#backend), follow these steps:
+
+1. Sign in to your Wordpress backend.
+2. Go to **WooCommerce** > **MultiSafepay Settings** > **Payment Methods** > **Credit Card**, and then click **Manage**.
+3. Click in the **Payment Components** checkbox to enable this feature.
+4. Click **Save changes**.
+
+For questions, email the Integration Team at <integration@multisafepay.com>
+
+**Note:** If you have a custom checkout and encounter a conflict with the Payment Component, the Integration Team will do their best to provide support, but we can't guarantee compatibility in all cases.

--- a/content/integration/ready-made/woocommerce/faq/activating-payment-component.md
+++ b/content/integration/ready-made/woocommerce/faq/activating-payment-component.md
@@ -20,7 +20,7 @@ To activate the Payment Component in your Wordpress - WooCommerce [backend](/glo
 
 1. Sign in to your Wordpress backend.
 2. Go to **WooCommerce** > **MultiSafepay settings** > **Payment methods** > **Credit card**, and then click **Manage**.
-3. Click in the **Payment Components** checkbox to enable this feature.
+3. Select the **Payment components** checkbox.
 4. Click **Save changes**.
 
 For questions, email the Integration Team at <integration@multisafepay.com>


### PR DESCRIPTION
This PR introduce a new WooCommerce FAQ item about how to enable the payment component within the Credit Card gateway settings page.