### PR TITLE
Release of 5.2.0 PrestaShop plugin

### DIFF
--- a/content/integration/ready-made/prestashop-1-7/_index.md
+++ b/content/integration/ready-made/prestashop-1-7/_index.md
@@ -2,7 +2,7 @@
 title : "MultiSafepay plugin for PrestaShop 1.7"
 github_url : "https://github.com/MultiSafepay/prestashop-official"
 meta_title: "PrestaShop 1.7 plugin - MultiSafepay Docs"
-download_url : "https://github.com/MultiSafepay/prestashop-official/releases/download/5.1.1/Plugin_PrestaShop_5.1.1.zip"
+download_url : "https://github.com/MultiSafepay/prestashop-official/releases/download/5.2.0/Plugin_PrestaShop_5.2.0.zip"
 changelog_url : "."
 faq: "."
 logo: "/logo/Plugins/PrestaShop.svg"


### PR DESCRIPTION
This PR changes the download link of PrestaShop 1.7 plugin. 