### PR TITLE
PLGMAG2V2-431: Add info about setting custom order status

### DIFF
--- a/content/integration/ready-made/magento2/_index.md
+++ b/content/integration/ready-made/magento2/_index.md
@@ -67,7 +67,6 @@ Features that are no longer available:
 
 - Recurring Payments – replaced by Magento Vault and Instant Purchase
 - FastCheckout – no longer supported
-- PWA (REST) endpoints – replaced by GraphQL endpoints
 
 {{< /details >}}
 

--- a/content/integration/ready-made/magento2/faq/features-of-latest-release.md
+++ b/content/integration/ready-made/magento2/faq/features-of-latest-release.md
@@ -30,14 +30,18 @@ This feature is still supported in the new plugin, but it now uses the following
 
 ## Order status
 
-We have removed the following **Order status** fields:
+As of version 2.16, the following MultiSafepay statuses can be assigned to a Magento order status:
 
-- **Declined**
-- **Canceled**
-- **Expired** 
-- **Chargeback**
-
-All MultiSafepay statuses now set the order to the default **Canceled** status via the offline action.
+- **initialized**
+- **uncleared**
+- **reserved**
+- **chargeback**
+- **refunded**
+- **partial refunded**
+- **void**
+- **declined**
+- **expired**
+- **canceled**
 
 ## Order status flow  
 

--- a/content/integration/ready-made/magento2/faq/features-of-latest-release.md
+++ b/content/integration/ready-made/magento2/faq/features-of-latest-release.md
@@ -32,16 +32,16 @@ This feature is still supported in the new plugin, but it now uses the following
 
 As of version 2.16, the following MultiSafepay statuses can be assigned to a Magento order status:
 
-- **initialized**
-- **uncleared**
-- **reserved**
-- **chargeback**
-- **refunded**
-- **partial refunded**
-- **void**
-- **declined**
-- **expired**
-- **canceled**
+- **Cancelled**
+- **Chargeback**
+- **Declined**
+- **Expired**
+- **Initialized**
+- **Partial refunded**
+- **Refunded**
+- **Reserved**
+- **Uncleared**
+- **Void**
 
 ## Order status flow  
 


### PR DESCRIPTION
As of version 2.15, PWA REST endpoints are back in the plugin, because of high demand. Therefore, I removed it from the features that are no longer available.

This task was initially created to describe which MultiSafepay statuses can now be coupled to Magento order statuses.