### PR TITLE
DOCS-3242: Adjustment in OpenCart PHP version requirement

### DIFF
--- a/content/integration/ready-made/opencart/_index.md
+++ b/content/integration/ready-made/opencart/_index.md
@@ -42,7 +42,7 @@ Contact us:
 &nbsp;  
 - MultiSafepay account – See [Getting started](/getting-started/).
 - OpenCart 2.X, 3.X
-- Tested on PHP 7.2, 7.3
+- PHP version 7.2, 7.3, or 7.4
 
 {{< /details >}}
 


### PR DESCRIPTION
This PR changes a little bit the requirements of the OpenCart plugin, to declare PHP versions supported