### PR TITLE
Update recurring payments for release 2.6.0

### DIFF
--- a/content/integration/ready-made/shopware6/faq/enabling-recurring-payments.md
+++ b/content/integration/ready-made/shopware6/faq/enabling-recurring-payments.md
@@ -9,5 +9,5 @@ aliases:
     - /payments/integrations/ecommerce-platforms/shopware6/faq/enabling-tokenization/
 ---
 
-You need to [enable recurring payments](/features/recurring-payments) in your MultiSafepay dashboard and then in the plugin settings. 
+You need to [enable recurring payments](/features/recurring-payments) in your MultiSafepay dashboard and then in the gateway settings. 
 


### PR DESCRIPTION
Since the new release of the Shopware 6 (2.6.0) plugin, we have moved the tokenizations (and the newly created payment component) setting to the gateway level to enable it individually. Therefore this change.

_sidenote: Since this update. Merchants have to re-enable tokenization on the gateway level. This is mentioned in the changelog on github_