### PR TITLE
Release of WooCommerce Plugin 4.15.0

### DIFF
--- a/content/integration/ready-made/woocommerce/_index.md
+++ b/content/integration/ready-made/woocommerce/_index.md
@@ -1,7 +1,7 @@
 ---
 title : "MultiSafepay plugin for WooCommerce"
 github_url : "https://github.com/MultiSafepay/WooCommerce"
-download_url : "https://github.com/MultiSafepay/WooCommerce/releases/download/4.13.1/Plugin_WooCommerce_4.13.1.zip"
+download_url : "https://github.com/MultiSafepay/WooCommerce/releases/download/4.15.0/Plugin_WooCommerce_4.15.0.zip"
 changelog_url : "."
 faq: "."
 repo_url : "MultiSafepay/WooCommerce"


### PR DESCRIPTION
This PR changes the download link of the WooCommerce plugin. 