### PR TITLE
Correct the token location in the payment-data response for Google Pay

### DIFF
--- a/content/integration/wallet-integrations/google-direct/_index.md
+++ b/content/integration/wallet-integrations/google-direct/_index.md
@@ -287,7 +287,7 @@ For more information about the `paymentData` object, see Google Pay&nbsp;–&nbs
 
 From your server, [create an order](https://docs-api.multisafepay.com/reference/createorder) > Wallet order. See also Examples > Google Pay direct.
 
-For the `gateway_info.payment_token`, use `PaymentData.PaymentMethodData.PaymentMethodTokenizationData.token`.
+For the `gateway_info.payment_token`, use `paymentData.paymentMethodData.tokenizationData.token`.
 
 ## Step 6: Redirect the customer
 


### PR DESCRIPTION
The token-location mentioned in the Google Pay integration was incorrect. Also, in the paragraph above an example is mentioned which is 'unfindable'.

Do the changes meet MultiSafepay Docs' Definition of Done? *IDK*

