### PR TITLE
Release of WooCommerce Plugin 4.17.2

### DIFF
--- a/content/integrations/woocommerce.md
+++ b/content/integrations/woocommerce.md
@@ -11,7 +11,7 @@ slug: 'woocommerce'
 
 <div style="display: flex; flex-wrap: wrap;">
 
-<a class="suggestEdits" style="display: inline-flex; border-radius: 5px; padding: 10px 20px; margin: 10px; font-size: 1rem; background-color: #006ba1; color: #ffffff; text-decoration: none;" href="https://github.com/MultiSafepay/WooCommerce/releases/download/4.17.1/Plugin_WooCommerce_4.17.1.zip" target="_self"><span>Download</span><i class="icon icon-download" style="margin-left: 0.6em;"> </i></a>
+<a class="suggestEdits" style="display: inline-flex; border-radius: 5px; padding: 10px 20px; margin: 10px; font-size: 1rem; background-color: #006ba1; color: #ffffff; text-decoration: none;" href="https://github.com/MultiSafepay/WooCommerce/releases/download/4.17.2/Plugin_WooCommerce_4.17.2.zip" target="_self"><span>Download</span><i class="icon icon-download" style="margin-left: 0.6em;"> </i></a>
 
 <a class="suggestEdits" style="display: inline-flex; border-radius: 5px; padding: 10px 20px; margin: 10px; font-size: 1rem; background-color: #DFEBF6; color: #0a59a1; text-decoration: none;" href="https://github.com/MultiSafepay/WooCommerce" target="_blank"><i class="icon-external-link"></i> <span>Source code</span></a>
 

--- a/content/integrations/woocommerce.md
+++ b/content/integrations/woocommerce.md
@@ -11,7 +11,7 @@ slug: 'woocommerce'
 
 <div style="display: flex; flex-wrap: wrap;">
 
-<a class="suggestEdits" style="display: inline-flex; border-radius: 5px; padding: 10px 20px; margin: 10px; font-size: 1rem; background-color: #006ba1; color: #ffffff; text-decoration: none;" href="https://github.com/MultiSafepay/WooCommerce/releases/download/4.16.0/Plugin_WooCommerce_4.16.0.zip" target="_self"><span>Download</span><i class="icon icon-download" style="margin-left: 0.6em;"> </i></a>
+<a class="suggestEdits" style="display: inline-flex; border-radius: 5px; padding: 10px 20px; margin: 10px; font-size: 1rem; background-color: #006ba1; color: #ffffff; text-decoration: none;" href="https://github.com/MultiSafepay/WooCommerce/releases/download/4.17.1/Plugin_WooCommerce_4.17.1.zip" target="_self"><span>Download</span><i class="icon icon-download" style="margin-left: 0.6em;"> </i></a>
 
 <a class="suggestEdits" style="display: inline-flex; border-radius: 5px; padding: 10px 20px; margin: 10px; font-size: 1rem; background-color: #DFEBF6; color: #0a59a1; text-decoration: none;" href="https://github.com/MultiSafepay/WooCommerce" target="_blank"><i class="icon-external-link"></i> <span>Source code</span></a>
 
@@ -30,6 +30,13 @@ slug: 'woocommerce'
 > **Tip!** We recommend first installing the plugin in a test environment, following the WooCommerce installation procedure. Always make a backup.
 
 There are two ways to install the plugin:
+
+**Wordpress installation**
+
+1. Sign in to your WooCommerce backend.
+2. Go to **Plugins** > **Add new**.
+3. Search for **MultiSafepay**.
+4. For the **MultiSafepay plugin for WooCommerce**, click the **Install now** button.
 
 **Manual installation**
 


### PR DESCRIPTION
This PR: 

- Update the download link according new release. 
- Restore the instructions to install the plugin via Wordpress backend. 
