### PR TITLE
DOCS-3882:Clarify how invoice_id is displayed

### DIFF
--- a/content/payment-methods/paypal.md
+++ b/content/payment-methods/paypal.md
@@ -121,7 +121,7 @@ We strongly recommend [testing transactions](/docs/testing/) before processing l
 
 - A `shopping_cart` object can be included in your [create order](/reference/createorder) request, see Recipe – [Include shopping_cart in order](/recipes/display-shopping-cart).
 
-- A unique `invoice_id`  can be included in your [create order](/reference/createorder) request, which is displayed on the transaction history.<br> When an `invoice_id` is not set in your request, a unique `order_id` will be displayed.
+- An `invoice_id`  can be included in your [create order](/reference/createorder) request, which appears in the transaction history.<br> **Note:** If no `invoice_id` is set, the `order_id` defaults to `invoice_id`.
 
 - Transactions expire after 14 days.
 


### PR DESCRIPTION
Do the changes meet MultiSafepay Docs' Definition of Done?
- Style guide, tone of voice, and naming conventions
- Tested
- Reviewed on mobile, tablet and desktop screens
- Notified stakeholders
- Pass GitHub Actions
