### PR TITLE
DOCS-3895: Changing the supported version of OpenCart 4

### DIFF
--- a/content/integrations/opencart-4.md
+++ b/content/integrations/opencart-4.md
@@ -26,7 +26,7 @@ slug: 'opencart-4'
 # Prerequisites
 
 - [MultiSafepay account](/docs/getting-started-guide/)
-- OpenCart 4.x
+- OpenCart 4.0.1.x
 - PHP version 8.0, 8.1
 
 # Installation


### PR DESCRIPTION
OpenCart 4 launched a version recently with some changes that the integration team needs to cover in the near future.

Because of this, we need to be more specific about the version of Opencart 4 compatible with our plugin and to change the more generalist OpenCart 4.x to 4.0.1.x