### PR TITLE
PLGVIR4-43: Changing the URL of VirtueMart 4 plugin [Release 1.0.1]

### DIFF
--- a/content/integrations/virtuemart-4.md
+++ b/content/integrations/virtuemart-4.md
@@ -11,7 +11,7 @@ slug: 'virtuemart-4'
 
 <div style="display: flex; flex-wrap: wrap;">
 
-<a class="suggestEdits" style="display: inline-flex; border-radius: 5px; padding: 10px 20px; margin: 10px; font-size: 1rem; background-color: #006ba1; color: #ffffff; text-decoration: none;" href="https://github.com/MultiSafepay/virtuemart-4/releases/download/1.0.0/Plugin_VirtueMart-4_1.0.0.zip" target="_self"><span>Download</span><i class="icon icon-download" style="margin-left: 0.6em;"> </i></a>
+<a class="suggestEdits" style="display: inline-flex; border-radius: 5px; padding: 10px 20px; margin: 10px; font-size: 1rem; background-color: #006ba1; color: #ffffff; text-decoration: none;" href="https://github.com/MultiSafepay/virtuemart-4/releases/download/1.0.1/Plugin_VirtueMart-4_1.0.1.zip" target="_self"><span>Download</span><i class="icon icon-download" style="margin-left: 0.6em;"> </i></a>
 
 <a class="suggestEdits" style="display: inline-flex; border-radius: 5px; padding: 10px 20px; margin: 10px; font-size: 1rem; background-color: #DFEBF6; color: #0a59a1; text-decoration: none;" href="https://github.com/MultiSafepay/virtuemart-4" target="_blank"><i class="icon-external-link"></i> <span>Source code</span></a>
 


### PR DESCRIPTION
As we have released VirtueMart 4 - Version 1.0.1, the URL to download it needs to be changed.