### PR TITLE
PLGWOOS-868: Release of the 5.3.0 of the WooCommerce plugin

### DIFF
--- a/content/integrations/woocommerce.md
+++ b/content/integrations/woocommerce.md
@@ -11,7 +11,7 @@ slug: 'woocommerce'
 
 <div style="display: flex; flex-wrap: wrap;">
 
-<a class="suggestEdits" style="display: inline-flex; border-radius: 5px; padding: 10px 20px; margin: 10px; font-size: 1rem; background-color: #006ba1; color: #ffffff; text-decoration: none;" href="https://github.com/MultiSafepay/woocommerce/releases/download/5.2.2/Plugin_WooCommerce_5.2.2.zip" target="_self"><span>Download</span><i class="icon icon-download" style="margin-left: 0.6em;"> </i></a>
+<a class="suggestEdits" style="display: inline-flex; border-radius: 5px; padding: 10px 20px; margin: 10px; font-size: 1rem; background-color: #006ba1; color: #ffffff; text-decoration: none;" href="https://wordpress.org/plugins/multisafepay/" target="_self"><span>Download</span><i class="icon icon-download" style="margin-left: 0.6em;"> </i></a>
 
 <a class="suggestEdits" style="display: inline-flex; border-radius: 5px; padding: 10px 20px; margin: 10px; font-size: 1rem; background-color: #DFEBF6; color: #0a59a1; text-decoration: none;" href="https://github.com/MultiSafepay/WooCommerce" target="_blank"><i class="icon-external-link"></i> <span>Source code</span></a>
 


### PR DESCRIPTION
This PR updates the download link, and instead of pointing to the release asset in GitHub, I just changed it to point to the WordPress marketplace. This way is not required to change this page, after each release. 