### PR TITLE
PRES-402 & PRES-404: For PrestaShop 1.7

### DIFF
--- a/content/integrations/prestashop-1-7.md
+++ b/content/integrations/prestashop-1-7.md
@@ -27,7 +27,7 @@ slug: 'prestashop-1-7'
 # Prerequisites
 
 - [MultiSafepay account](/docs/getting-started-guide/)
-- PrestaShop 1.7.6 and above or PrestaShop 8.1.x
+- PrestaShop 1.7.6 up to PrestaShop 8.1.x
 - PHP version 7.2 or higher
 
 # Installation


### PR DESCRIPTION
PRES-402: Establish the highest supported version of our plugin for PrestaShop
PRES-404: Release of 5.11.2