### PR TITLE
DOCS-4454: Add explanation about API Key setting field to Shopify docs

### DIFF
--- a/content/integrations/shopify-beta.md
+++ b/content/integrations/shopify-beta.md
@@ -49,9 +49,9 @@ To install or migrate, follow these steps:
 
 <br>
 
-> ⚠️ About API Key and Selected environment
+> ⚠️ About API key and Selected environment
 >
-> For all the above-listed MultiSafepay payment apps, the same API Key, and the selected environment (test or live) will be used. Once you change the API key in a payment app, or the environment selected, it is automatically changed for the other active apps associated with your shop.
+> For all the above-listed MultiSafepay payment apps, the same API key, and the selected environment (test or live) will be used. Once you change the API key in a payment app, or the environment selected, it is automatically changed for the other active apps associated with your shop.
 
 <br>
 ---

--- a/content/integrations/shopify-beta.md
+++ b/content/integrations/shopify-beta.md
@@ -47,9 +47,13 @@ To install or migrate, follow these steps:
    - Enable Test Mode if you are using a Test API key. Turn off for a Live API key.
    - Enable or disable payment icons according to your preferences.
 
-&nbsp; **💡 Tip!** We recommend first testing each payment method before setting your **live** API key. 
 <br>
 
+> ⚠️ About API Key and Selected environment
+>
+> For all the above-listed MultiSafepay payment apps, the same API Key, and the selected environment (test or live) will be used. Once you change the API key in a payment app, or the environment selected, it is automatically changed for the other active apps associated with your shop.
+
+<br>
 ---
 
 # Uninstallation


### PR DESCRIPTION
This pull request includes an update to the `content/integrations/shopify-beta.md` file to provide clearer guidance on API key usage and environment selection for MultiSafepay payment apps.

Documentation improvements:

* Added a new section explaining that the same API key and selected environment (test or live) will be used across all MultiSafepay payment apps. Any changes to the API key or environment in one app will automatically apply to other active apps associated with the shop.