### PR TITLE
[Shopware 6] - Updating the version compatibility list

### DIFF
--- a/content/integrations/shopware-6.md
+++ b/content/integrations/shopware-6.md
@@ -21,8 +21,8 @@ slug: 'shopware-6'
 ## Prerequisites
 
 - [MultiSafepay account](/docs/getting-started-guide/)
-- Shopware 6.4.11.x or higher, 6.5.x.x and 6.6.x.x <!--_(<a href="https://www.shopware.com/en/pricing" target="_blank">Starter Edition</a> <i class="fa fa-external-link" style="font-size:12px;color:#8b929e"></i> supported)_-->
-- Tested on Shopware 6.4.20.2, 6.5.8.11, 6.6.3.0 and PHP 8.1–8.2
+- Shopware 6.6.x.x
+- Tested on Shopware 6.6.3.0 and PHP 8.1–8.2
 
 ## Installation and configuration
 


### PR DESCRIPTION
______________________________
**NOTE**:  To provide clearer information about our plugin's compatibility with Shopware 6, we have removed older versions from the documentation.
______________________________
**DESCRIPTION**:

This pull request includes a small update to the `content/integrations/shopware-6.md` file. The changes simplify the prerequisites for Shopware compatibility and testing.

* Updated the Shopware version requirement to only include 6.6.x.x and removed references to older versions.
* Updated the tested versions to include only Shopware 6.6.3.0 and PHP 8.1–8.2.