### PR TITLE
DOCS-4479: Release of 1.7.1 of the CS Cart plugin

### DIFF
--- a/content/integrations/cs-cart.md
+++ b/content/integrations/cs-cart.md
@@ -11,7 +11,7 @@ slug: 'cs-cart'
 
 <div style="display: flex; flex-wrap: wrap;">
 
-<a class="suggestEdits" style="display: inline-flex; border-radius: 5px; padding: 10px 20px; margin: 10px; font-size: 1rem; background-color: #006ba1; color: #ffffff; text-decoration: none;" href="https://github.com/MultiSafepay/CS-Cart/releases/download/1.7.0/Plugin_CS-Cart_1.7.0.zip" target="_self"><span>Download</span><i class="icon icon-download" style="margin-left: 0.6em;"> </i></a>
+<a class="suggestEdits" style="display: inline-flex; border-radius: 5px; padding: 10px 20px; margin: 10px; font-size: 1rem; background-color: #006ba1; color: #ffffff; text-decoration: none;" href="https://github.com/MultiSafepay/CS-Cart/releases/download/1.7.1/Plugin_CS-Cart_1.7.1.zip" target="_self"><span>Download</span><i class="icon icon-download" style="margin-left: 0.6em;"> </i></a>
 
 <a class="suggestEdits" style="display: inline-flex; border-radius: 5px; padding: 10px 20px; margin: 10px; font-size: 1rem; background-color: #DFEBF6; color: #0a59a1; text-decoration: none;" href="https://github.com/MultiSafepay/CS-Cart" target="_blank"><i class="icon-external-link"></i> <span>Source code</span></a>
 


### PR DESCRIPTION
This pull request includes an update to the download link for the CS-Cart plugin in the `content/integrations/cs-cart.md` file. The most important change is the update of the plugin version in the download link.

Update to CS-Cart plugin:

* [`content/integrations/cs-cart.md`](diffhunk://#diff-43c230de9916f1d549d83a8c0ed455196eda916f29dbb87b3e9481dd08696c2bL14-R14): Updated the download link to point to version 1.7.1 of the CS-Cart plugin.