### PR TITLE
DOCS-4623: [PrestaShop 1.6] Release of 3.15.0

### DIFF
--- a/content/integrations/prestashop-1-6.md
+++ b/content/integrations/prestashop-1-6.md
@@ -11,7 +11,7 @@ slug: 'prestashop-1-6'
 
 <div style="display: flex; flex-wrap: wrap;">
 
-<a class="suggestEdits" style="display: inline-flex; border-radius: 5px; padding: 10px 20px; margin: 10px; font-size: 1rem; background-color: #006ba1; color: #ffffff; text-decoration: none;" href="https://github.com/MultiSafepay/prestashop-1.6/releases/download/3.14.0/Plugin_PrestaShop_1_6_3.14.0.zip" target="_self"><span>Download</span><i class="icon icon-download" style="margin-left: 0.6em;"> </i></a>
+<a class="suggestEdits" style="display: inline-flex; border-radius: 5px; padding: 10px 20px; margin: 10px; font-size: 1rem; background-color: #006ba1; color: #ffffff; text-decoration: none;" href="https://github.com/MultiSafepay/prestashop-1.6/releases/download/3.15.0/Plugin_PrestaShop_1_6_3.15.0.zip" target="_self"><span>Download</span><i class="icon icon-download" style="margin-left: 0.6em;"> </i></a>
 
 <a class="suggestEdits" style="display: inline-flex; border-radius: 5px; padding: 10px 20px; margin: 10px; font-size: 1rem; background-color: #DFEBF6; color: #0a59a1; text-decoration: none;" href="https://github.com/MultiSafepay/prestashop-1.6" target="_blank"><i class="icon-external-link"></i> <span>Source code</span></a>
 


### PR DESCRIPTION
This pull request updates the download link for the PrestaShop 1.6 plugin in the documentation to point to the latest version (3.15.0).

* [`content/integrations/prestashop-1-6.md`](diffhunk://#diff-decda0f5c2080fad5aac4227dadbd8bb1849c29dbce398550906ecf24dfd8873L14-R14): Updated the `href` attribute of the download button to reference version 3.15.0 of the PrestaShop 1.6 plugin.